### PR TITLE
Fix webview timeout prompt config and macOS UI handling

### DIFF
--- a/packages/vscode/test/extension.test.js
+++ b/packages/vscode/test/extension.test.js
@@ -20,10 +20,12 @@ suite('Extension Test Suite', () => {
     assert.ok(ext, 'Extension not found: xiadengma.ai-intervention-agent')
 
     const webviewJsPath = path.join(ext.extensionPath, 'webview.js')
+    const webviewHelpersPath = path.join(ext.extensionPath, 'webview-helpers.js')
     const webviewUiPath = path.join(ext.extensionPath, 'webview-ui.js')
     const extPkgPath = path.join(ext.extensionPath, 'package.json')
 
     assert.ok(fs.existsSync(webviewJsPath), 'Missing webview.js in extension')
+    assert.ok(fs.existsSync(webviewHelpersPath), 'Missing webview-helpers.js in extension')
     assert.ok(fs.existsSync(webviewUiPath), 'Missing webview-ui.js in extension')
     assert.ok(fs.existsSync(extPkgPath), 'Missing package.json in extension')
 
@@ -33,6 +35,7 @@ suite('Extension Test Suite', () => {
 
     // 新功能回归点：插入代码按钮（剪贴板链路）
     assert.ok(webviewJs.includes('id="insertCodeBtn"'))
+    assert.ok(webviewJs.includes('webview-helpers.js'))
     assert.ok(webviewUi.includes('requestClipboardText'))
     assert.ok(webviewUi.includes('clipboardText'))
 
@@ -43,9 +46,82 @@ suite('Extension Test Suite', () => {
     // 边界回归点：自动提交与 429 应有护栏（避免重试风暴/并发提交）
     assert.ok(webviewUi.includes('autoSubmitAttempted'))
     assert.ok(webviewUi.includes('submitBackoffUntilMs'))
+    assert.ok(/async function autoSubmit\(\)[\s\S]*fetchFeedbackPrompts\(/.test(webviewUi))
+    assert.ok(webviewUi.includes('collectImageFilesFromClipboard'))
+    assert.ok(webviewUi.includes('applyHostThemeState'))
 
     // 配置回归点：应提供 logLevel 配置项（便于排查问题）
     assert.ok(extPkg.includes('ai-intervention-agent.logLevel'))
+  })
+
+  test('Webview helpers 应覆盖 macOS / 剪贴板 / 主题同步兼容逻辑', () => {
+    const ext = vscode.extensions.getExtension('xiadengma.ai-intervention-agent')
+    assert.ok(ext, 'Extension not found: xiadengma.ai-intervention-agent')
+
+    const helpersPath = path.join(ext.extensionPath, 'webview-helpers.js')
+    const helpers = require(helpersPath)
+
+    assert.strictEqual(helpers.detectMacLikePlatform({ platform: 'MacIntel' }), true)
+    assert.strictEqual(
+      helpers.detectMacLikePlatform({ userAgentData: { platform: 'macOS' } }),
+      true
+    )
+    assert.strictEqual(helpers.detectMacLikePlatform({ platform: 'Linux x86_64' }), false)
+
+    const clipboardFromFilesOnly = {
+      items: [],
+      files: [
+        { name: 'clip.png', type: 'image/png', size: 12, lastModified: 1 },
+        { name: 'note.txt', type: 'text/plain', size: 3, lastModified: 2 }
+      ]
+    }
+    const filesOnly = helpers.collectImageFilesFromClipboard(clipboardFromFilesOnly)
+    assert.strictEqual(filesOnly.length, 1)
+    assert.strictEqual(filesOnly[0].name, 'clip.png')
+
+    const sharedImage = { name: 'dup.png', type: 'image/png', size: 99, lastModified: 9 }
+    const clipboardWithDuplicateSources = {
+      items: [
+        {
+          kind: 'file',
+          type: 'image/png',
+          getAsFile: () => sharedImage
+        }
+      ],
+      files: [sharedImage]
+    }
+    const deduped = helpers.collectImageFilesFromClipboard(clipboardWithDuplicateSources)
+    assert.strictEqual(deduped.length, 1)
+    assert.strictEqual(deduped[0].name, 'dup.png')
+
+    const appliedAttrs = {}
+    const html = {
+      style: {},
+      setAttribute: (key, value) => {
+        appliedAttrs[key] = value
+      },
+      getAttribute: key => appliedAttrs[key]
+    }
+    const lightClasses = new Set(['vscode-light'])
+    const fakeDocument = {
+      body: {
+        classList: {
+          contains: value => lightClasses.has(value)
+        }
+      },
+      documentElement: html,
+      defaultView: {
+        getComputedStyle: () => ({
+          colorScheme: 'light',
+          backgroundColor: 'rgb(250, 250, 250)'
+        })
+      }
+    }
+
+    const themeKind = helpers.applyThemeKindToDocument(fakeDocument)
+    assert.strictEqual(themeKind, 'light')
+    assert.strictEqual(appliedAttrs['data-vscode-theme-kind'], 'light')
+    assert.strictEqual(html.style.colorScheme, 'light')
   })
 
   test('Logger 应避免在 LogOutputChannel 上重复前缀', () => {

--- a/packages/vscode/webview-helpers.js
+++ b/packages/vscode/webview-helpers.js
@@ -1,0 +1,161 @@
+/* eslint-disable */
+(function (root, factory) {
+  const api = factory()
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api
+  }
+  if (root) {
+    root.AIIAWebviewHelpers = api
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  function getNavigatorValue(nav, key) {
+    if (!nav || typeof nav !== 'object') return ''
+    const value = nav[key]
+    return typeof value === 'string' ? value : ''
+  }
+
+  function detectMacLikePlatform(nav) {
+    const uaDataPlatform =
+      nav &&
+      nav.userAgentData &&
+      typeof nav.userAgentData.platform === 'string'
+        ? nav.userAgentData.platform
+        : ''
+    const platform = getNavigatorValue(nav, 'platform')
+    const userAgent = getNavigatorValue(nav, 'userAgent')
+    const maxTouchPoints =
+      nav && Number.isFinite(Number(nav.maxTouchPoints))
+        ? Number(nav.maxTouchPoints)
+        : 0
+
+    const haystacks = [uaDataPlatform, platform, userAgent]
+      .filter(Boolean)
+      .map((value) => value.toLowerCase())
+
+    if (haystacks.some((value) => value.includes('mac'))) return true
+    if (haystacks.some((value) => /iphone|ipad|ipod/.test(value))) return true
+
+    // iPadOS 桌面模式经常暴露为 MacIntel，但同时存在触摸点。
+    if (platform === 'MacIntel' && maxTouchPoints > 1) return true
+
+    return false
+  }
+
+  function buildClipboardFileKey(file) {
+    if (!file) return ''
+    return [
+      file.name || '',
+      file.type || '',
+      Number.isFinite(Number(file.size)) ? Number(file.size) : '',
+      Number.isFinite(Number(file.lastModified)) ? Number(file.lastModified) : ''
+    ].join('::')
+  }
+
+  function pushUniqueImageFile(target, seenKeys, file) {
+    if (!file || !file.type || !String(file.type).startsWith('image/')) return
+    const key = buildClipboardFileKey(file)
+    if (key && seenKeys.has(key)) return
+    if (key) seenKeys.add(key)
+    target.push(file)
+  }
+
+  function collectImageFilesFromClipboard(clipboardData) {
+    const files = []
+    const seenKeys = new Set()
+    if (!clipboardData) return files
+
+    const items = Array.from(clipboardData.items || [])
+    for (const item of items) {
+      if (!item || item.kind !== 'file') continue
+      if (!item.type || !String(item.type).startsWith('image/')) continue
+      const file = typeof item.getAsFile === 'function' ? item.getAsFile() : null
+      pushUniqueImageFile(files, seenKeys, file)
+    }
+
+    if (files.length > 0) return files
+
+    const clipboardFiles = Array.from(clipboardData.files || [])
+    for (const file of clipboardFiles) {
+      pushUniqueImageFile(files, seenKeys, file)
+    }
+    return files
+  }
+
+  function parseRgbColor(color) {
+    if (!color) return null
+    const value = String(color).trim()
+    if (!value) return null
+    const match = value.match(/^rgba?\(([^)]+)\)$/i)
+    if (!match) return null
+    const parts = match[1].split(',').map((part) => Number(part.trim()))
+    if (parts.length < 3 || parts.slice(0, 3).some((part) => !Number.isFinite(part))) {
+      return null
+    }
+    return { r: parts[0], g: parts[1], b: parts[2] }
+  }
+
+  function resolveThemeKind(doc) {
+    const body = doc && doc.body
+    const html = doc && doc.documentElement
+    if (body && body.classList) {
+      if (
+        body.classList.contains('vscode-light') ||
+        body.classList.contains('vscode-high-contrast-light')
+      ) {
+        return 'light'
+      }
+      if (
+        body.classList.contains('vscode-dark') ||
+        body.classList.contains('vscode-high-contrast')
+      ) {
+        return 'dark'
+      }
+    }
+
+    if (doc && typeof doc.defaultView !== 'undefined' && body) {
+      try {
+        const colorScheme = String(doc.defaultView.getComputedStyle(body).colorScheme || '').toLowerCase()
+        if (colorScheme.includes('light')) return 'light'
+        if (colorScheme.includes('dark')) return 'dark'
+
+        const rgb = parseRgbColor(doc.defaultView.getComputedStyle(body).backgroundColor)
+        if (rgb) {
+          const luminance = (0.2126 * rgb.r) + (0.7152 * rgb.g) + (0.0722 * rgb.b)
+          return luminance < 128 ? 'dark' : 'light'
+        }
+      } catch (_) {
+        // ignore
+      }
+    }
+
+    if (html && html.getAttribute) {
+      const existing = html.getAttribute('data-vscode-theme-kind')
+      if (existing === 'light' || existing === 'dark') {
+        return existing
+      }
+    }
+
+    return 'dark'
+  }
+
+  function applyThemeKindToDocument(doc) {
+    const html = doc && doc.documentElement
+    if (!html) return 'dark'
+
+    const themeKind = resolveThemeKind(doc)
+    if (typeof html.setAttribute === 'function') {
+      html.setAttribute('data-vscode-theme-kind', themeKind)
+    }
+    if (html.style) {
+      html.style.colorScheme = themeKind
+    }
+    return themeKind
+  }
+
+  return {
+    applyThemeKindToDocument,
+    collectImageFilesFromClipboard,
+    detectMacLikePlatform,
+    resolveThemeKind
+  }
+})

--- a/packages/vscode/webview-ui.js
+++ b/packages/vscode/webview-ui.js
@@ -15,6 +15,11 @@ const SERVER_URL = (__cfgEl && __cfgEl.getAttribute('data-server-url')) ? __cfgE
 const CSP_NONCE = (__cfgEl && __cfgEl.getAttribute('data-csp-nonce')) ? __cfgEl.getAttribute('data-csp-nonce') : '';
 const LOTTIE_LIB_URL = (__cfgEl && __cfgEl.getAttribute('data-lottie-lib-url')) ? __cfgEl.getAttribute('data-lottie-lib-url') : '';
 const NO_CONTENT_LOTTIE_JSON_URL = (__cfgEl && __cfgEl.getAttribute('data-no-content-lottie-json-url')) ? __cfgEl.getAttribute('data-no-content-lottie-json-url') : '';
+    const WEBVIEW_HELPERS =
+        (typeof window !== 'undefined' && window.AIIAWebviewHelpers)
+            ? window.AIIAWebviewHelpers
+            : null;
+    let themeObserver = null;
     // 无有效内容页面：Lottie 动画（对齐原项目：sprout.json；失败则降级为 🌱）
     let noContentHourglassAnimation = null;
 
@@ -66,6 +71,41 @@ const NO_CONTENT_LOTTIE_JSON_URL = (__cfgEl && __cfgEl.getAttribute('data-no-con
         const container = document.getElementById('hourglass-lottie');
         if (!container) return;
         container.style.filter = isDarkBackground() ? 'invert(1)' : 'none';
+    }
+
+    function isMacLikePlatform() {
+        try {
+            if (WEBVIEW_HELPERS && typeof WEBVIEW_HELPERS.detectMacLikePlatform === 'function') {
+                return !!WEBVIEW_HELPERS.detectMacLikePlatform(navigator);
+            }
+        } catch (e) {
+            // ignore
+        }
+        return !!(navigator && navigator.platform && navigator.platform.includes('Mac'));
+    }
+
+    function applyHostThemeState() {
+        try {
+            if (WEBVIEW_HELPERS && typeof WEBVIEW_HELPERS.applyThemeKindToDocument === 'function') {
+                WEBVIEW_HELPERS.applyThemeKindToDocument(document);
+            }
+        } catch (e) {
+            // ignore
+        }
+        updateNoContentHourglassColor();
+    }
+
+    function installHostThemeObserver() {
+        applyHostThemeState();
+        if (themeObserver || typeof MutationObserver === 'undefined' || !document.body) return;
+
+        themeObserver = new MutationObserver(() => {
+            applyHostThemeState();
+        });
+        themeObserver.observe(document.body, {
+            attributes: true,
+            attributeFilter: ['class']
+        });
     }
 
     function destroyNoContentHourglassAnimation() {
@@ -211,6 +251,10 @@ const NO_CONTENT_LOTTIE_JSON_URL = (__cfgEl && __cfgEl.getAttribute('data-no-con
     // 【对齐服务端】server_time/deadline/remaining_time 支持（用于倒计时不漂移）
     let serverTimeOffset = 0;     // 服务器时间 - 本地时间（秒）
     let taskDeadlines = {};       // task_id -> deadline（秒级时间戳）
+    let feedbackPrompts = {
+        resubmit_prompt: '请立即调用 interactive_feedback 工具',
+        prompt_suffix: '\n请积极调用 interactive_feedback 工具'
+    };
     // 【对齐原始实现】多任务输入状态：每个任务独立保存输入/选项/图片，避免切换任务时“串任务”
     let taskTextareaContents = {}; // task_id -> string
     let taskOptionsStates = {};    // task_id -> { [index:number]: boolean } | boolean[]
@@ -270,6 +314,39 @@ const NO_CONTENT_LOTTIE_JSON_URL = (__cfgEl && __cfgEl.getAttribute('data-no-con
     function logError(message) {
         console.error('[Webview]', message);
         vscode.postMessage({ type: 'error', message: String(message) });
+    }
+
+    async function fetchFeedbackPrompts(fetchOptions) {
+        let controller = null;
+        let timeoutId = null;
+        try {
+            const options = fetchOptions ? { ...fetchOptions } : { cache: 'no-store' };
+            if (!options.cache) options.cache = 'no-store';
+
+            if (typeof AbortController !== 'undefined') {
+                controller = new AbortController();
+                options.signal = controller.signal;
+                timeoutId = setTimeout(() => {
+                    try { controller.abort(); } catch (e) { /* ignore */ }
+                }, POLL_CONFIG_TIMEOUT_MS);
+            }
+
+            const response = await fetch(SERVER_URL + '/api/get-feedback-prompts', options);
+            if (!response.ok) return feedbackPrompts;
+
+            const payload = await response.json();
+            if (payload && payload.status === 'success' && payload.config) {
+                feedbackPrompts = {
+                    resubmit_prompt: payload.config.resubmit_prompt || feedbackPrompts.resubmit_prompt,
+                    prompt_suffix: payload.config.prompt_suffix || feedbackPrompts.prompt_suffix
+                };
+            }
+        } catch (e) {
+            log('获取反馈提示语失败，使用缓存值: ' + (e && e.message ? e.message : String(e)));
+        } finally {
+            if (timeoutId) clearTimeout(timeoutId);
+        }
+        return feedbackPrompts;
     }
 
     // 插入剪贴板代码：在光标处插入 fenced code block（对齐“插入代码”按钮预期）
@@ -376,6 +453,7 @@ const NO_CONTENT_LOTTIE_JSON_URL = (__cfgEl && __cfgEl.getAttribute('data-no-con
 
     /* 初始化函数 */
     async function init() {
+        installHostThemeObserver();
         setupEventListeners();
         // 默认先标记为未连接，避免长时间停留在“连接中...”的误导状态
         updateServerStatus(false);
@@ -458,7 +536,7 @@ const NO_CONTENT_LOTTIE_JSON_URL = (__cfgEl && __cfgEl.getAttribute('data-no-con
                 });
                 // 【体验对齐】Ctrl/Cmd + Enter 提交
                 textarea.addEventListener('keydown', (e) => {
-                    const isMac = !!(navigator && navigator.platform && navigator.platform.includes('Mac'));
+                    const isMac = isMacLikePlatform();
                     const ctrlOrCmd = isMac ? e.metaKey : e.ctrlKey;
                     if (ctrlOrCmd && e.key === 'Enter') {
                         e.preventDefault();
@@ -2217,8 +2295,16 @@ const NO_CONTENT_LOTTIE_JSON_URL = (__cfgEl && __cfgEl.getAttribute('data-no-con
         }
         stopCountdown();
 
-        // 构建默认反馈消息（固定文本，引导AI继续调用工具）
-        const defaultMessage = '请立即调用 interactive_feedback 工具';
+        // 自动提交前实时拉取一次配置，确保 resubmit_prompt 热更新能立刻生效
+        let defaultMessage = '请立即调用 interactive_feedback 工具';
+        try {
+            const prompts = await fetchFeedbackPrompts();
+            if (prompts && prompts.resubmit_prompt) {
+                defaultMessage = String(prompts.resubmit_prompt);
+            }
+        } catch (e) {
+            // ignore，保留默认文案兜底
+        }
 
         await submitWithData(defaultMessage, [], taskId);
 
@@ -2743,22 +2829,36 @@ const NO_CONTENT_LOTTIE_JSON_URL = (__cfgEl && __cfgEl.getAttribute('data-no-con
     }
 
     function handlePaste(e) {
-        const items = e.clipboardData?.items;
-        if (!items) return;
+        const clipboardData = e && e.clipboardData;
+        if (!clipboardData) return;
 
-        const imageFiles = [];
-        for (let i = 0; i < items.length; i++) {
-            const item = items[i];
-            if (item && item.type && item.type.startsWith('image/')) {
-                const file = item.getAsFile();
-                if (file) {
-                    imageFiles.push(file);
+        let imageFiles = [];
+        try {
+            if (WEBVIEW_HELPERS && typeof WEBVIEW_HELPERS.collectImageFilesFromClipboard === 'function') {
+                imageFiles = WEBVIEW_HELPERS.collectImageFilesFromClipboard(clipboardData);
+            }
+        } catch (err) {
+            imageFiles = [];
+        }
+
+        if (!imageFiles.length) {
+            const items = clipboardData.items || [];
+            for (let i = 0; i < items.length; i++) {
+                const item = items[i];
+                if (item && item.type && item.type.startsWith('image/')) {
+                    const file = item.getAsFile();
+                    if (file) {
+                        imageFiles.push(file);
+                    }
                 }
             }
         }
 
         if (imageFiles.length > 0) {
-            e.preventDefault(); // 阻止默认粘贴行为
+            const pastedText = (clipboardData.getData('text/plain') || clipboardData.getData('text') || '').trim();
+            if (!pastedText) {
+                e.preventDefault(); // 纯图片粘贴时阻止默认行为，避免 textarea 出现占位文本
+            }
             processImages(imageFiles);
             log('从剪贴板粘贴了 ' + imageFiles.length + ' 张图片');
         }
@@ -2858,6 +2958,14 @@ const NO_CONTENT_LOTTIE_JSON_URL = (__cfgEl && __cfgEl.getAttribute('data-no-con
         stopPolling();
         stopCountdown();
         clearAllTabCountdowns();
+        if (themeObserver) {
+            try {
+                themeObserver.disconnect();
+            } catch (e) {
+                // ignore
+            }
+            themeObserver = null;
+        }
     });
 
     function reportFatalError(prefix, err) {

--- a/packages/vscode/webview.js
+++ b/packages/vscode/webview.js
@@ -341,6 +341,7 @@ class WebviewProvider {
     const markedJsUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'marked.min.js'))
     const prismJsUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'prism.min.js'))
     const prismCssUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'prism.min.css'))
+    const webviewHelpersUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'webview-helpers.js'))
     const webviewUiUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'webview-ui.js'))
     const extensionVersion = EXT_VERSION || '0.0.0'
     const githubUrl = EXT_GITHUB_URL || ''
@@ -671,10 +672,12 @@ class WebviewProvider {
         }
 
         /* VSCode 浅色主题：参考原项目的浅色进度条配色 */
+        html[data-vscode-theme-kind="light"] .no-content-progress,
         body.vscode-light .no-content-progress {
             box-shadow: none;
             background: rgba(0, 0, 0, 0.05);
         }
+        html[data-vscode-theme-kind="light"] .no-content-progress-bar,
         body.vscode-light .no-content-progress-bar {
             background: #e3dacc; /* 奶油米色 */
         }
@@ -1323,9 +1326,9 @@ class WebviewProvider {
             width: 100%;
             padding: 8px 10px;
             border-radius: 8px;
-            border: 1px solid rgba(127, 127, 127, 0.22);
-            background: rgba(0, 0, 0, 0.12);
-            color: var(--vscode-foreground);
+            border: 1px solid var(--vscode-input-border, rgba(127, 127, 127, 0.22));
+            background: var(--vscode-input-background);
+            color: var(--vscode-input-foreground);
             outline: none;
         }
 
@@ -1371,12 +1374,12 @@ class WebviewProvider {
         }
 
         .settings-action.secondary {
-            background: rgba(255, 255, 255, 0.06);
-            color: var(--vscode-foreground);
+            background: var(--vscode-button-secondaryBackground, rgba(255, 255, 255, 0.06));
+            color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
         }
 
         .settings-action.secondary:hover {
-            background: rgba(255, 255, 255, 0.10);
+            background: var(--vscode-button-secondaryHoverBackground, rgba(255, 255, 255, 0.10));
         }
 
         .settings-hint {
@@ -1391,7 +1394,8 @@ class WebviewProvider {
             padding: 2px 8px;
             border-radius: 999px;
             border: 1px solid rgba(127, 127, 127, 0.25);
-            background: rgba(255, 255, 255, 0.04);
+            background: var(--vscode-badge-background, rgba(255, 255, 255, 0.04));
+            color: var(--vscode-badge-foreground, var(--vscode-foreground));
             user-select: none;
         }
 
@@ -1445,8 +1449,8 @@ class WebviewProvider {
             padding: 2px 6px;
             border-radius: 6px;
             border: 1px solid rgba(127, 127, 127, 0.25);
-            background: rgba(0, 0, 0, 0.12);
-            color: var(--vscode-foreground);
+            background: var(--vscode-badge-background, rgba(0, 0, 0, 0.12));
+            color: var(--vscode-badge-foreground, var(--vscode-foreground));
             opacity: 0.85;
         }
 
@@ -1462,8 +1466,8 @@ class WebviewProvider {
             line-height: 0;
             border-radius: 6px;
             border: 1px solid rgba(127, 127, 127, 0.25);
-            background: rgba(0, 0, 0, 0.18);
-            color: var(--vscode-foreground);
+            background: var(--vscode-button-secondaryBackground, rgba(0, 0, 0, 0.18));
+            color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
         }
 
         .code-toolbar .copy-button svg {
@@ -1473,7 +1477,7 @@ class WebviewProvider {
         }
 
         .code-toolbar .copy-button:hover {
-            background: rgba(0, 0, 0, 0.28);
+            background: var(--vscode-button-secondaryHoverBackground, rgba(0, 0, 0, 0.28));
         }
 
         .code-toolbar .copy-button.copied {
@@ -1678,6 +1682,7 @@ class WebviewProvider {
     <!-- marked.js for Markdown rendering -->
     <script nonce="${nonce}" src="${markedJsUri}"></script>
 
+        <script nonce="${nonce}" src="${webviewHelpersUri}"></script>
         <script nonce="${nonce}" src="${webviewUiUri}"></script>
 </body>
 </html>`

--- a/tests/test_feedback_hot_reload.py
+++ b/tests/test_feedback_hot_reload.py
@@ -121,3 +121,24 @@ class TestGetFeedbackPromptsAPIValidation(unittest.TestCase):
         self.assertEqual(
             data["config"]["prompt_suffix"], "\n请积极调用 interactive_feedback 工具"
         )
+
+    @patch("web_ui.get_config")
+    def test_custom_strings_passthrough(self, mock_get_config):
+        """resubmit_prompt/prompt_suffix 非空时应原样返回给前端"""
+        from pathlib import Path
+
+        mock_cfg = MagicMock()
+        mock_cfg.get_section.return_value = {
+            "resubmit_prompt": "请重新调用自定义工具",
+            "prompt_suffix": "\n继续等待用户输入",
+        }
+        mock_cfg.config_file = Path("/tmp/custom-config.jsonc")
+        mock_get_config.return_value = mock_cfg
+
+        resp = self.client.get("/api/get-feedback-prompts")
+        self.assertEqual(resp.status_code, 200)
+
+        data = resp.get_json()
+        self.assertEqual(data["status"], "success")
+        self.assertEqual(data["config"]["resubmit_prompt"], "请重新调用自定义工具")
+        self.assertEqual(data["config"]["prompt_suffix"], "\n继续等待用户输入")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make the VS Code/Cursor webview fetch `feedback.resubmit_prompt` before timeout auto-submit instead of using a hardcoded fallback
- add shared webview helpers for macOS platform detection, clipboard image extraction, and theme-kind syncing
- update webview theme styling to use VS Code theme tokens and add regression coverage for prompt/config, clipboard, and theme helpers

## Testing
- `uv run pytest tests/test_feedback_hot_reload.py tests/test_feedback_config.py -q`
- `npm test` (in `packages/vscode`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-933fd8f9-38a8-4388-9e4d-516a1443cc2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-933fd8f9-38a8-4388-9e4d-516a1443cc2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

