### PR TITLE
Fix macOS web notifications and config merging

### DIFF
--- a/scripts/minify_assets.py
+++ b/scripts/minify_assets.py
@@ -149,7 +149,7 @@ def process_directory(
             saved_percent = (saved / original_size * 100) if original_size > 0 else 0
             total_saved += saved
 
-            print(f"✅ {filepath.name} -> {minified_path.name}")
+            print(f"已生成 {filepath.name} -> {minified_path.name}")
             print(f"   原始大小: {original_size:,} bytes")
             print(f"   压缩后:  {minified_size:,} bytes")
             print(f"   节省:    {saved:,} bytes ({saved_percent:.1f}%)")
@@ -158,7 +158,7 @@ def process_directory(
             files_processed += 1
 
         except Exception as e:
-            print(f"❌ 处理失败 {filepath.name}: {e}")
+            print(f"处理失败 {filepath.name}: {e}")
 
     print(f"处理完成: {files_processed} 个文件, 跳过 {files_skipped} 个")
     if total_saved > 0:
@@ -204,11 +204,11 @@ def main():
         total = needs_js + needs_css
         if total > 0:
             print(
-                f"❌ 检查失败：发现 {total} 个静态资源需要重新生成 .min 文件。"
+                f"检查失败：发现 {total} 个静态资源需要重新生成 .min 文件。"
                 "请运行：python scripts/minify_assets.py"
             )
             sys.exit(1)
-        print("✅ 检查通过：所有 .min 文件都是最新的。")
+        print("检查通过：所有 .min 文件都是最新的。")
     else:
         print("完成！")
 

--- a/server.py
+++ b/server.py
@@ -456,7 +456,7 @@ class WebUIConfig:
         # 特权端口警告
         if self.port < self.PORT_PRIVILEGED:
             logger.warning(
-                f"⚠️  端口 {self.port} 是特权端口（<{self.PORT_PRIVILEGED}），"
+                f"端口 {self.port} 是特权端口（<{self.PORT_PRIVILEGED}），"
                 f"可能需要 root/管理员权限才能绑定"
             )
 
@@ -1002,7 +1002,7 @@ def update_web_content(
 
         if response.status_code == 200:
             logger.info(
-                f"📝 内容已更新: {cleaned_summary[:50]}... (task_id: {task_id})"
+                f"内容已更新: {cleaned_summary[:50]}... (task_id: {task_id})"
             )
 
             # 验证更新是否成功
@@ -1387,7 +1387,7 @@ def launch_feedback_ui(
     task_id: Optional[str] = None,
     timeout: int = 300,
 ) -> Dict[str, Any]:
-    """⚠️ 废弃：旧版 Python API，推荐使用 interactive_feedback() MCP 工具"""
+    """废弃：旧版 Python API，推荐使用 interactive_feedback() MCP 工具"""
     # 确保超时时间不小于300秒（0表示无限等待，保持不变）
     if timeout > 0:
         timeout = max(timeout, 300)

--- a/server.py
+++ b/server.py
@@ -1001,9 +1001,7 @@ def update_web_content(
         response = session.post(url, json=data, timeout=config.timeout)
 
         if response.status_code == 200:
-            logger.info(
-                f"内容已更新: {cleaned_summary[:50]}... (task_id: {task_id})"
-            )
+            logger.info(f"内容已更新: {cleaned_summary[:50]}... (task_id: {task_id})")
 
             # 验证更新是否成功
             try:

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -69,14 +69,14 @@ let config = null
 //   - 叶子颜色因 invert 也会变化（可接受的视觉效果）
 //
 // 降级处理：
-//   若 Lottie 库加载失败，显示 🌱 emoji 作为备用
+//   若 Lottie 库加载失败，显示内置 SVG/CSS 备用图标
 // ==================================================================
 
 // Lottie 动画实例引用（用于后续控制如暂停/销毁）
 let hourglassAnimation = null
 
 /**
- * 渲染“嫩芽”动画的 SVG/CSS 降级版本（替代 emoji 🌱）
+ * 渲染“嫩芽”动画的 SVG/CSS 降级版本
  *
  * 设计目标：
  * - 不依赖外部资源（JSON/网络/库）
@@ -121,8 +121,8 @@ function renderSproutFallback(container) {
       </svg>
     `
   } catch (e) {
-    // 最后兜底：极端情况下（SVG/CSS 注入失败），仍回退到 emoji
-    container.textContent = '🌱'
+    // 最后兜底：极端情况下显示文本提示，避免再退化为 emoji
+    container.textContent = '等待中'
   }
 }
 
@@ -135,7 +135,7 @@ function renderSproutFallback(container) {
  *   3. 销毁已有动画（防止内存泄漏）
  *   4. 创建新动画实例
  *   5. 监听加载完成事件，应用主题颜色
- *   6. 监听错误事件，显示降级 emoji
+ *   6. 监听错误事件，显示降级图标
  */
 function initHourglassAnimation() {
   const container = document.getElementById('hourglass-lottie')
@@ -180,7 +180,7 @@ function initHourglassAnimation() {
       renderSproutFallback(container)
     })
 
-    console.log('✅ 嫩芽动画初始化成功')
+    console.log('嫩芽动画初始化成功')
   } catch (error) {
     console.error('Lottie 动画初始化失败:', error)
     renderSproutFallback(container) // 降级为 SVG/CSS 动画
@@ -214,7 +214,7 @@ function updateLottieAnimationColor() {
     container.style.filter = 'invert(1)'
   }
 
-  console.log('✅ Lottie 动画颜色已更新:', isLightTheme ? '浅色模式（原色）' : '深色模式（反转）')
+  console.log('Lottie 动画颜色已更新:', isLightTheme ? '浅色模式（原色）' : '深色模式（反转）')
 }
 
 // 监听主题变化事件（由 ThemeManager 在 theme.js 中派发）
@@ -974,6 +974,11 @@ class NotificationManager {
     this.permission = this.isSupported ? Notification.permission : 'denied'
     this.audioContext = null
     this.audioBuffers = new Map()
+    this.serviceWorkerRegistration = null
+    this.initPromise = null
+    this.permissionRequestPromise = null
+    this.autoPermissionListenersBound = false
+    this.boundPermissionRequestHandler = null
     this.config = {
       enabled: true,
       webEnabled: true,
@@ -986,52 +991,172 @@ class NotificationManager {
       mobileOptimized: true,
       mobileVibrate: true
     }
-    this.init()
   }
 
   async init() {
-    console.log('初始化通知管理器...')
-
-    // 检查浏览器支持
-    if (!this.isSupported) {
-      console.warn('浏览器不支持Web Notification API')
-      return
+    if (this.initPromise) {
+      return this.initPromise
     }
 
-    // 自动请求通知权限
-    if (this.config.autoRequestPermission && this.permission === 'default') {
-      await this.requestPermission()
-    }
+    this.initPromise = (async () => {
+      console.log('初始化通知管理器...')
+      this.syncPermissionState()
 
-    // 初始化音频系统
-    await this.initAudio()
+      if (!this.isSupported) {
+        console.warn('浏览器不支持 Web Notification API')
+      } else {
+        await this.registerServiceWorker()
+        this.bindAutoPermissionRequest()
+      }
 
-    console.log('通知管理器初始化完成')
+      await this.initAudio()
+      console.log('通知管理器初始化完成')
+    })()
+
+    return this.initPromise
   }
 
-  async requestPermission() {
-    if (!this.isSupported) {
-      console.warn('浏览器不支持Web Notification API')
-      return false
+  syncPermissionState() {
+    this.permission = this.isSupported ? Notification.permission : 'denied'
+    return this.permission
+  }
+
+  supportsServiceWorkerNotifications() {
+    return (
+      typeof navigator !== 'undefined' &&
+      'serviceWorker' in navigator &&
+      window.isSecureContext
+    )
+  }
+
+  async registerServiceWorker() {
+    if (!this.supportsServiceWorkerNotifications()) {
+      if (!window.isSecureContext) {
+        console.warn('当前不是安全上下文，无法注册通知 service worker')
+      }
+      return null
+    }
+
+    if (this.serviceWorkerRegistration) {
+      return this.serviceWorkerRegistration
     }
 
     try {
-      // 兼容旧版本浏览器的权限请求方式
-      if (Notification.requestPermission.length === 0) {
-        // 新版本 - 返回Promise
-        this.permission = await Notification.requestPermission()
-      } else {
-        // 旧版本 - 使用回调
-        this.permission = await new Promise(resolve => {
-          Notification.requestPermission(resolve)
-        })
+      await navigator.serviceWorker.register('/notification-service-worker.js')
+      this.serviceWorkerRegistration = await navigator.serviceWorker.ready
+      console.log('通知 service worker 已注册')
+      return this.serviceWorkerRegistration
+    } catch (error) {
+      console.warn('通知 service worker 注册失败:', error)
+      return null
+    }
+  }
+
+  bindAutoPermissionRequest() {
+    if (!this.isSupported) return
+
+    if (!this.config.autoRequestPermission || this.syncPermissionState() !== 'default') {
+      this.removeAutoPermissionRequestListeners()
+      return
+    }
+
+    if (this.autoPermissionListenersBound) {
+      return
+    }
+
+    this.boundPermissionRequestHandler = () => {
+      if (!this.config.autoRequestPermission) {
+        this.removeAutoPermissionRequestListeners()
+        return
       }
 
-      console.log(`通知权限状态: ${this.permission}`)
-      return this.permission === 'granted'
+      if (this.syncPermissionState() !== 'default') {
+        this.removeAutoPermissionRequestListeners()
+        return
+      }
+
+      this.requestPermission({ requireUserGesture: false }).finally(() => {
+        if (this.syncPermissionState() !== 'default') {
+          this.removeAutoPermissionRequestListeners()
+        }
+      })
+    }
+
+    ;['click', 'keydown', 'touchstart'].forEach(eventName => {
+      document.addEventListener(eventName, this.boundPermissionRequestHandler, {
+        once: true,
+        passive: true
+      })
+    })
+
+    this.autoPermissionListenersBound = true
+  }
+
+  removeAutoPermissionRequestListeners() {
+    if (!this.autoPermissionListenersBound || !this.boundPermissionRequestHandler) {
+      return
+    }
+
+    ;['click', 'keydown', 'touchstart'].forEach(eventName => {
+      document.removeEventListener(eventName, this.boundPermissionRequestHandler)
+    })
+
+    this.autoPermissionListenersBound = false
+    this.boundPermissionRequestHandler = null
+  }
+
+  async requestPermission({ requireUserGesture = true } = {}) {
+    if (!this.isSupported) {
+      console.warn('浏览器不支持 Web Notification API')
+      return false
+    }
+
+    this.syncPermissionState()
+    if (this.permission === 'granted') {
+      return true
+    }
+
+    if (this.permission === 'denied') {
+      return false
+    }
+
+    if (
+      requireUserGesture &&
+      navigator.userActivation &&
+      navigator.userActivation.isActive === false
+    ) {
+      console.warn('通知权限请求需要用户操作，已延迟到下一次交互')
+      this.bindAutoPermissionRequest()
+      return false
+    }
+
+    if (this.permissionRequestPromise) {
+      return this.permissionRequestPromise
+    }
+
+    try {
+      this.permissionRequestPromise = (async () => {
+        if (Notification.requestPermission.length === 0) {
+          this.permission = await Notification.requestPermission()
+        } else {
+          this.permission = await new Promise(resolve => {
+            Notification.requestPermission(resolve)
+          })
+        }
+
+        console.log(`通知权限状态: ${this.permission}`)
+        return this.permission === 'granted'
+      })()
+
+      return await this.permissionRequestPromise
     } catch (error) {
       console.error('请求通知权限失败:', error)
       return false
+    } finally {
+      this.permissionRequestPromise = null
+      if (this.permission !== 'default') {
+        this.removeAutoPermissionRequestListeners()
+      }
     }
   }
 
@@ -1077,41 +1202,106 @@ class NotificationManager {
 
   async showNotification(title, message, options = {}) {
     if (!this.config.enabled || !this.config.webEnabled) {
-      console.log('Web通知已禁用')
+      console.log('Web 通知已禁用')
       return null
     }
 
     if (!this.isSupported) {
       console.warn('浏览器不支持通知，使用降级方案')
-      this.showFallbackNotification(title, message)
+      this.showFallbackNotification(title, message, { ...options, reason: 'unsupported' })
       return null
     }
 
+    this.syncPermissionState()
     if (this.permission !== 'granted') {
-      console.warn('没有通知权限')
+      console.warn('当前没有系统通知权限')
       if (this.config.autoRequestPermission) {
-        await this.requestPermission()
-        if (this.permission !== 'granted') {
-          this.showFallbackNotification(title, message)
+        const granted = await this.requestPermission({
+          requireUserGesture: !(navigator.userActivation && navigator.userActivation.isActive)
+        })
+        if (!granted) {
+          this.showFallbackNotification(title, message, {
+            ...options,
+            reason: this.permission === 'denied' ? 'permission_denied' : 'permission_default'
+          })
           return null
         }
       } else {
-        this.showFallbackNotification(title, message)
+        this.showFallbackNotification(title, message, {
+          ...options,
+          reason: 'permission_disabled'
+        })
         return null
       }
     }
 
     try {
+      const {
+        onClick,
+        url,
+        data: extraData,
+        icon,
+        badge,
+        tag,
+        requireInteraction,
+        silent,
+        ...restOptions
+      } = options
+
       const notificationOptions = {
         body: message,
-        icon: options.icon || this.config.icon,
-        badge: options.badge || this.config.icon,
-        tag: options.tag || 'ai-intervention-agent',
-        requireInteraction: options.requireInteraction || false,
-        silent: options.silent || false,
-        ...options
+        icon: icon || this.config.icon,
+        badge: badge || this.config.icon,
+        tag: tag || 'ai-intervention-agent',
+        requireInteraction: requireInteraction || false,
+        silent: silent || false,
+        data: {
+          url: url || window.location.href,
+          ...extraData
+        },
+        ...restOptions
       }
 
+      const notification = await this.showSystemNotification(
+        title,
+        notificationOptions,
+        { ...restOptions, onClick }
+      )
+
+      if (!notification) {
+        this.showFallbackNotification(title, message, {
+          ...options,
+          reason: 'system_notification_failed'
+        })
+        return null
+      }
+
+      console.log('系统通知已显示:', title)
+      return notification
+    } catch (error) {
+      console.error('显示通知失败:', error)
+      this.showFallbackNotification(title, message, {
+        ...options,
+        reason: 'show_notification_exception'
+      })
+      return null
+    }
+  }
+
+  async showSystemNotification(title, notificationOptions, options = {}) {
+    const registration = await this.registerServiceWorker()
+    if (registration && typeof registration.showNotification === 'function') {
+      try {
+        await registration.showNotification(title, notificationOptions)
+        return {
+          close() {}
+        }
+      } catch (error) {
+        console.warn('通过 service worker 显示通知失败，回退到页面 Notification:', error)
+      }
+    }
+
+    try {
       const notification = new Notification(title, notificationOptions)
 
       // 设置超时自动关闭
@@ -1135,10 +1325,9 @@ class NotificationManager {
         navigator.vibrate([200, 100, 200])
       }
 
-      console.log('通知已显示:', title)
       return notification
     } catch (error) {
-      console.error('显示通知失败:', error)
+      console.error('页面 Notification 创建失败:', error)
       return null
     }
   }
@@ -1336,7 +1525,7 @@ class NotificationManager {
     }
 
     // 4. 尝试使用控制台样式输出
-    console.log(`%c🔔 ${title}`, 'color: #0084ff; font-weight: bold; font-size: 14px;')
+    console.log(`%c[通知] ${title}`, 'color: #0084ff; font-weight: bold; font-size: 14px;')
     console.log(`%c${message}`, 'color: #666; font-size: 12px;')
 
     // 5. 记录降级事件用于统计
@@ -1354,7 +1543,7 @@ class NotificationManager {
     const maxFlashes = 6
 
     const flashInterval = setInterval(() => {
-      document.title = flashCount % 2 === 0 ? `🔔 ${message}` : originalTitle
+      document.title = flashCount % 2 === 0 ? `[通知] ${message}` : originalTitle
       flashCount++
 
       if (flashCount >= maxFlashes) {
@@ -1366,6 +1555,8 @@ class NotificationManager {
 
   updateConfig(newConfig) {
     this.config = { ...this.config, ...newConfig }
+    this.syncPermissionState()
+    this.bindAutoPermissionRequest()
     console.log('通知配置已更新:', this.config)
   }
 
@@ -1373,6 +1564,7 @@ class NotificationManager {
     return {
       supported: this.isSupported,
       permission: this.permission,
+      serviceWorkerRegistered: Boolean(this.serviceWorkerRegistration),
       audioContext: this.audioContext ? this.audioContext.state : 'unavailable',
       config: this.config
     }
@@ -1652,7 +1844,8 @@ class SettingsManager {
     console.log(`设置已更新: ${key} = ${value}`)
   }
 
-  applySettings() {
+  applySettings(options = {}) {
+    const { syncBackend = true } = options
     // 更新前端通知管理器配置
     if (notificationManager) {
       notificationManager.updateConfig({
@@ -1673,7 +1866,9 @@ class SettingsManager {
     }
 
     // 同步配置到后端
-    this.syncConfigToBackend()
+    if (syncBackend) {
+      this.syncConfigToBackend()
+    }
   }
 
   async syncConfigToBackend() {
@@ -1893,7 +2088,7 @@ class SettingsManager {
       this.applySettingsTheme()
     }
 
-    // ✅ 方案A：每次打开设置面板，都从后端刷新一次配置
+    // 每次打开设置面板都从后端刷新一次配置
     // 目的：
     // - 让“外部编辑 config.jsonc”能在不刷新页面的情况下反映到 UI
     // - 避免打开面板时把旧的本地缓存配置反向写回后端（覆盖外部修改）
@@ -2887,7 +3082,7 @@ function initializePasteFunction() {
     }
   }
 
-  // ⚠️ 防重复注册：
+  // 防重复注册：
   // 某些场景下（例如脚本被重复执行、或初始化函数被重复调用），会导致 paste 监听器被注册多次，
   // 从而出现“粘贴一次添加两张重复图片”的问题。这里通过“先移除旧 handler，再注册新 handler”保证幂等。
   try {
@@ -3216,7 +3411,7 @@ function initializeApp() {
   loadConfig()
     .then(() => {
       // 配置加载完成
-      console.log('✅ 配置加载完成')
+      console.log('配置加载完成')
       console.log('当前配置:', {
         has_content: config.has_content,
         persistent: config.persistent,
@@ -3233,10 +3428,10 @@ function initializeApp() {
       }
     })
     .catch(error => {
-      console.error('❌ 配置加载失败:', error)
+      console.error('配置加载失败:', error)
       // 即使配置加载失败，也尝试初始化多任务支持
       setTimeout(() => {
-        console.log('🔄 配置加载失败，延迟初始化多任务支持...')
+        console.log('配置加载失败，延迟初始化多任务支持...')
         // startContentPolling() // 已停用
 
         // 初始化多任务支持（内含任务轮询）
@@ -3255,21 +3450,18 @@ function initializeApp() {
   // 初始化快捷键提示
   initializeShortcutTooltip()
 
-  // 初始化设置管理器（必须在 DOM 加载完成后）
-  settingsManager.init().catch(error => {
-    console.warn('设置管理器初始化失败:', error)
-  })
-
-  // 初始化通知管理器
-  notificationManager
+  // 初始化设置管理器并在其配置就绪后再启动通知管理器
+  settingsManager
     .init()
     .then(() => {
+      settingsManager.applySettings({ syncBackend: false })
+      return notificationManager.init()
+    })
+    .then(() => {
       console.log('通知管理器初始化完成')
-      // 应用设置管理器的配置
-      settingsManager.applySettings()
     })
     .catch(error => {
-      console.warn('通知管理器初始化失败:', error)
+      console.warn('设置或通知管理器初始化失败:', error)
     })
 
   // 按钮事件

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1145,6 +1145,11 @@ class NotificationManager {
         }
 
         console.log(`通知权限状态: ${this.permission}`)
+        window.dispatchEvent(
+          new CustomEvent('notification-permission-changed', {
+            detail: { permission: this.permission }
+          })
+        )
         return this.permission === 'granted'
       })()
 
@@ -2060,6 +2065,10 @@ class SettingsManager {
       } else if (e.target.id === 'bark-action') {
         this.updateSetting('barkAction', e.target.value)
       }
+    })
+
+    window.addEventListener('notification-permission-changed', () => {
+      this.updateStatus()
     })
   }
 

--- a/static/js/app.min.js
+++ b/static/js/app.min.js
@@ -1,12 +1,94 @@
-;(function redirectZeroHostToLoopback(){try{const url=new URL(window.location.href)
-if(url.hostname==='0.0.0.0'){url.hostname='127.0.0.1'
-console.warn(`检测到访问地址为 0.0.0.0，已自动切换为 ${url.origin}（避免浏览器兼容性问题）`)
-window.location.replace(url.toString())}}catch(e){}})()
-let config=null
-let hourglassAnimation=null
-function renderSproutFallback(container){if(!container)return
-try{container.textContent=''
-container.innerHTML=`
+/**
+ * AI Intervention Agent - 主应用脚本
+ *
+ * 功能模块：
+ *   - Lottie 动画配置和初始化
+ *   - Markdown 渲染和代码高亮
+ *   - 页面状态管理（无内容页面/内容页面切换）
+ *   - 内容轮询逻辑
+ *   - 表单处理和提交
+ *   - 通知管理器
+ *   - 设置管理器
+ *   - 图片上传处理
+ *   - 应用初始化
+ *
+ * 依赖：
+ *   - mathjax-loader.js: MathJax 懒加载
+ *   - multi_task.js: 多任务管理
+ *   - theme.js: 主题管理
+ *   - dom-security.js: DOM 安全工具
+ *   - validation-utils.js: 验证工具
+ *   - marked.js: Markdown 解析
+ *   - prism.js: 代码高亮
+ *   - lottie.min.js: 动画库
+ */
+
+// ==================================================================
+// 访问地址兼容性处理（0.0.0.0 -> 127.0.0.1）
+// ==================================================================
+//
+// 背景：
+// - 0.0.0.0 是服务端“监听所有网卡”的绑定地址，适合服务端 bind，但不适合作为浏览器访问地址。
+// - 部分浏览器/环境下，访问 http://0.0.0.0:PORT 可能出现异常（如权限异常、请求失败、Failed to fetch）。
+//
+// 处理策略：
+// - 若检测到当前页面 hostname 为 0.0.0.0，则自动切换为 127.0.0.1（保持端口/路径/查询参数不变）
+// - 使用 location.replace 避免污染历史记录
+;(function redirectZeroHostToLoopback() {
+  try {
+    const url = new URL(window.location.href)
+    if (url.hostname === '0.0.0.0') {
+      url.hostname = '127.0.0.1'
+      console.warn(`检测到访问地址为 0.0.0.0，已自动切换为 ${url.origin}（避免浏览器兼容性问题）`)
+      window.location.replace(url.toString())
+    }
+  } catch (e) {
+    // 忽略：不影响主流程
+  }
+})()
+
+// 主题管理器已在 theme.js 中定义和初始化
+// 此处不再重复定义，避免 CSP nonce 和重复声明问题
+
+let config = null
+
+// ==================================================================
+// Lottie 嫩芽动画配置
+// ==================================================================
+//
+// 功能说明：
+//   在"无有效内容"页面显示循环播放的嫩芽生长动画，
+//   向用户传达"等待中/正在生长"的视觉隐喻。
+//
+// 动画来源：
+//   /static/lottie/sprout.json
+//
+// 主题适配：
+//   - 浅色模式：原色（深色线条）
+//   - 深色模式：通过 CSS filter: invert(1) 反转为白色线条
+//   - 叶子颜色因 invert 也会变化（可接受的视觉效果）
+//
+// 降级处理：
+//   若 Lottie 库加载失败，显示内置 SVG/CSS 备用图标
+// ==================================================================
+
+// Lottie 动画实例引用（用于后续控制如暂停/销毁）
+let hourglassAnimation = null
+
+/**
+ * 渲染“嫩芽”动画的 SVG/CSS 降级版本
+ *
+ * 设计目标：
+ * - 不依赖外部资源（JSON/网络/库）
+ * - 纯 SVG + CSS 动画，可在 Lottie 加载失败时仍提供动态反馈
+ * - 颜色由容器的 filter/invert 统一控制（对齐 updateLottieAnimationColor）
+ */
+function renderSproutFallback(container) {
+  if (!container) return
+  try {
+    // 清空容器（避免和 Lottie 的 SVG 叠加）
+    container.textContent = ''
+    container.innerHTML = `
       <svg
         width="48"
         height="48"
@@ -37,408 +119,1464 @@ container.innerHTML=`
           <path d="M18 44C20 40 28 40 30 44" stroke="#111" stroke-width="3" stroke-linecap="round"/>
         </g>
       </svg>
-    `}catch(e){container.textContent='🌱'}}
-function initHourglassAnimation(){const container=document.getElementById('hourglass-lottie')
-if(!container){console.warn('动画容器未找到')
-return}
-if(typeof lottie==='undefined'){console.warn('Lottie 库未加载，显示备用图标')
-renderSproutFallback(container)
-return}
-try{if(hourglassAnimation){hourglassAnimation.destroy()}
-hourglassAnimation=lottie.loadAnimation({container:container,renderer:'svg',loop:true,autoplay:true,path:'/static/lottie/sprout.json',rendererSettings:{preserveAspectRatio:'xMidYMid meet'}})
-hourglassAnimation.addEventListener('DOMLoaded',()=>{updateLottieAnimationColor()})
-hourglassAnimation.addEventListener('error',()=>{console.warn('Lottie 动画加载失败，显示备用图标')
-renderSproutFallback(container)})
-console.log('✅ 嫩芽动画初始化成功')}catch(error){console.error('Lottie 动画初始化失败:',error)
-renderSproutFallback(container)}}
-function updateLottieAnimationColor(){const container=document.getElementById('hourglass-lottie')
-if(!container)return
-const isLightTheme=document.documentElement.getAttribute('data-theme')==='light'
-if(isLightTheme){container.style.filter='none'}else{container.style.filter='invert(1)'}
-console.log('✅ Lottie 动画颜色已更新:',isLightTheme?'浅色模式（原色）':'深色模式（反转）')}
-window.addEventListener('theme-changed',event=>{console.log('主题变更事件:',event.detail)
-setTimeout(updateLottieAnimationColor,50)})
-function renderMarkdownContent(element,content,isMarkdown=false){requestAnimationFrame(()=>{if(content){let htmlContent=content
-if(isMarkdown&&typeof marked!=='undefined'){try{htmlContent=marked.parse(content)}catch(e){console.warn('marked.js 解析失败:',e)}}
-const fragment=document.createDocumentFragment()
-const tempDiv=document.createElement('div')
-tempDiv.innerHTML=htmlContent
-while(tempDiv.firstChild){fragment.appendChild(tempDiv.firstChild)}
-element.innerHTML=''
-element.appendChild(fragment)
-processCodeBlocks(element)
-processStrikethrough(element)
-const textContent=element.textContent||''
-if(window.loadMathJaxIfNeeded){window.loadMathJaxIfNeeded(element,textContent)}else if(window.MathJax&&window.MathJax.typesetPromise){window.MathJax.typesetPromise([element]).catch(err=>{console.warn('MathJax 渲染失败:',err)})}}else{element.textContent='加载中...'}})}
-function processCodeBlocks(container){const codeBlocks=container.querySelectorAll('pre')
-codeBlocks.forEach(pre=>{if(pre.parentElement&&pre.parentElement.classList.contains('code-block-container')){return}
-const codeContainer=document.createElement('div')
-codeContainer.className='code-block-container'
-pre.parentNode.insertBefore(codeContainer,pre)
-codeContainer.appendChild(pre)
-const codeElement=pre.querySelector('code')
-let language='text'
-if(codeElement&&codeElement.className){const langMatch=codeElement.className.match(/language-(\w+)/)
-if(langMatch){language=langMatch[1]}}
-const toolbar=document.createElement('div')
-toolbar.className='code-toolbar'
-if(language!=='text'){const langLabel=document.createElement('span')
-langLabel.className='language-label'
-langLabel.textContent=language.toUpperCase()
-toolbar.appendChild(langLabel)}
-const copyButton=DOMSecurity.createCopyButton(pre.textContent||'')
-toolbar.appendChild(copyButton)
-codeContainer.appendChild(toolbar)})}
-async function copyCodeToClipboard(preElement,button){const checkIconSvg='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" style="width: 14px; height: 14px; margin-right: 4px; vertical-align: middle;"><path fill-rule="evenodd" clip-rule="evenodd" d="M13.7803 4.21967C14.0732 4.51256 14.0732 4.98744 13.7803 5.28033L6.78033 12.2803C6.48744 12.5732 6.01256 12.5732 5.71967 12.2803L2.21967 8.78033C1.92678 8.48744 1.92678 8.01256 2.21967 7.71967C2.51256 7.42678 2.98744 7.42678 3.28033 7.71967L6.25 10.6893L12.7197 4.21967C13.0126 3.92678 13.4874 3.92678 13.7803 4.21967Z"/></svg>'
-const errorIconSvg='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" style="width: 14px; height: 14px; margin-right: 4px; vertical-align: middle;"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.21967 4.21967C4.51256 3.92678 4.98744 3.92678 5.28033 4.21967L8 6.93934L10.7197 4.21967C11.0126 3.92678 11.4874 3.92678 11.7803 4.21967C12.0732 4.51256 12.0732 4.98744 11.7803 5.28033L9.06066 8L11.7803 10.7197C12.0732 11.0126 12.0732 11.4874 11.7803 11.7803C11.4874 12.0732 11.0126 12.0732 10.7197 11.7803L8 9.06066L5.28033 11.7803C4.98744 12.0732 4.51256 12.0732 4.21967 11.7803C3.92678 11.4874 3.92678 11.0126 4.21967 10.7197L6.93934 8L4.21967 5.28033C3.92678 4.98744 3.92678 4.51256 4.21967 4.21967Z"/></svg>'
-try{const codeElement=preElement.querySelector('code')
-const textToCopy=codeElement?codeElement.textContent:preElement.textContent
-await navigator.clipboard.writeText(textToCopy)
-const originalHTML=button.innerHTML
-button.innerHTML=checkIconSvg+'已复制'
-button.classList.add('copied')
-setTimeout(()=>{button.innerHTML=originalHTML
-button.classList.remove('copied')},2000)}catch(err){console.error('复制失败:',err)
-const originalHTML=button.innerHTML
-button.innerHTML=errorIconSvg+'复制失败'
-button.classList.add('error')
-setTimeout(()=>{button.innerHTML=originalHTML
-button.classList.remove('error')},2000)}}
-function processStrikethrough(container){const walker=document.createTreeWalker(container,NodeFilter.SHOW_TEXT,{acceptNode:function(node){const parent=node.parentElement
-if(parent&&(parent.tagName==='CODE'||parent.tagName==='PRE'||parent.tagName==='SCRIPT'||parent.tagName==='STYLE'||parent.closest('pre, code, script, style'))){return NodeFilter.FILTER_REJECT}
-return NodeFilter.FILTER_ACCEPT}})
-const textNodes=[]
-let node
-while((node=walker.nextNode())){textNodes.push(node)}
-textNodes.forEach(textNode=>{const text=textNode.textContent
-const strikethroughRegex=/~~([^~\n]+?)~~/g
-if(strikethroughRegex.test(text)){const newHTML=text.replace(strikethroughRegex,'<del>$1</del>')
-const tempDiv=document.createElement('div')
-tempDiv.innerHTML=newHTML
-const fragment=document.createDocumentFragment()
-while(tempDiv.firstChild){fragment.appendChild(tempDiv.firstChild)}
-textNode.parentNode.replaceChild(fragment,textNode)}})}
-async function loadConfig(){try{const response=await fetch('/api/config')
-config=await response.json()
-if(!config.has_content){showNoContentPage()
-return}
-showContentPage()
-const descriptionElement=document.getElementById('description')
-renderMarkdownContent(descriptionElement,config.prompt_html||config.prompt)
-if(config.predefined_options&&config.predefined_options.length>0){const optionsContainer=document.getElementById('options-container')
-const separator=document.getElementById('separator')
-config.predefined_options.forEach((option,index)=>{const optionDiv=document.createElement('div')
-optionDiv.className='option-item'
-const checkbox=document.createElement('input')
-checkbox.type='checkbox'
-checkbox.id=`option-${index}`
-checkbox.value=option
-const label=document.createElement('label')
-label.htmlFor=`option-${index}`
-label.textContent=option
-optionDiv.appendChild(checkbox)
-optionDiv.appendChild(label)
-optionsContainer.appendChild(optionDiv)})
-optionsContainer.style.display='block'
-separator.style.display='block'}}catch(error){console.error('加载配置失败:',error)
-showStatus('加载配置失败','error')
-throw error}}
-function showNoContentPage(){document.getElementById('content-container').style.display='none'
-document.getElementById('no-content-container').style.display='flex'
-document.body.classList.add('no-content-mode')
-const taskTabsContainer=document.getElementById('task-tabs-container')
-if(taskTabsContainer){taskTabsContainer.classList.add('hidden')}
-if(config){document.getElementById('no-content-buttons').style.display='block'}}
-function showContentPage(){document.getElementById('content-container').style.display='block'
-document.getElementById('no-content-container').style.display='none'
-document.body.classList.remove('no-content-mode')
-enableSubmitButton()}
-function disableSubmitButton(){const submitBtn=document.getElementById('submit-btn')
-const insertBtn=document.getElementById('insert-code-btn')
-const feedbackText=document.getElementById('feedback-text')
-if(submitBtn){submitBtn.disabled=true
-submitBtn.style.backgroundColor='#3a3a3c'
-submitBtn.style.color='#8e8e93'
-submitBtn.style.cursor='not-allowed'}
-if(insertBtn){insertBtn.disabled=true
-insertBtn.style.backgroundColor='#3a3a3c'
-insertBtn.style.color='#8e8e93'
-insertBtn.style.cursor='not-allowed'}
-if(feedbackText){feedbackText.disabled=true
-feedbackText.style.backgroundColor='#2c2c2e'
-feedbackText.style.color='#8e8e93'
-feedbackText.style.cursor='not-allowed'}}
-function enableSubmitButton(){const submitBtn=document.getElementById('submit-btn')
-const insertBtn=document.getElementById('insert-code-btn')
-const feedbackText=document.getElementById('feedback-text')
-if(submitBtn){submitBtn.disabled=false
-submitBtn.style.backgroundColor='#0a84ff'
-submitBtn.style.color='#ffffff'
-submitBtn.style.cursor='pointer'}
-if(insertBtn){insertBtn.disabled=false
-insertBtn.style.backgroundColor='#48484a'
-insertBtn.style.color='#ffffff'
-insertBtn.style.cursor='pointer'}
-if(feedbackText){feedbackText.disabled=false
-feedbackText.style.backgroundColor='rgba(255, 255, 255, 0.03)'
-feedbackText.style.color='#f5f5f7'
-feedbackText.style.cursor='text'}}
-function showStatus(message,type){const noContentContainer=document.getElementById('no-content-container')
-const isNoContentPage=noContentContainer&&noContentContainer.style.display==='flex'
-if(!isNoContentPage&&type!=='error'){console.log(`[showStatus] 跳过非错误提示: ${message} (${type})`)
-return}
-const statusElement=isNoContentPage?document.getElementById('no-content-status-message'):document.getElementById('status-message')
-if(!statusElement)return
-statusElement.textContent=message
-statusElement.className=`status-message status-${type}`
-statusElement.style.display='block'
-if(type==='success'){setTimeout(()=>{statusElement.style.display='none'},3000)}}
-async function insertCodeFromClipboard(){let finished=false
-let fallbackTimer=null
-const finish=()=>{finished=true
-if(fallbackTimer){clearTimeout(fallbackTimer)
-fallbackTimer=null}}
-fallbackTimer=setTimeout(()=>{if(finished)return
-finish()
-openCodePasteModal(new Error('ClipboardReadTimeout'))},1500)
-try{if(!navigator.clipboard||typeof navigator.clipboard.readText!=='function'){finish()
-openCodePasteModal()
-return}
-const text=await navigator.clipboard.readText()
-if(finished)return
-finish()
-if(!text||!text.trim()){openCodePasteModal(new Error('ClipboardEmpty'))
-return}
-insertCodeBlockIntoFeedbackTextarea(text)
-showStatus('代码已插入','success')}catch(error){if(finished)return
-finish()
-console.error('读取剪贴板失败:',error)
-openCodePasteModal(error)}}
-function buildMarkdownCodeFence(text,lang=''){const normalizedText=String(text||'').replace(/\r\n?/g,'\n')
-if(!normalizedText.trim())return null
-const backtickRuns=normalizedText.match(/`+/g)||[]
-const longestRun=backtickRuns.reduce((max,run)=>Math.max(max,run.length),0)
-const fence='`'.repeat(Math.max(3,longestRun+1))
-const fenceHead=lang?`${fence}${lang}`:fence
-const codeBody=normalizedText.endsWith('\n')?normalizedText:`${normalizedText}\n`
-return`${fenceHead}\n${codeBody}${fence}`}
-function insertCodeBlockIntoFeedbackTextarea(text){const textarea=document.getElementById('feedback-text')
-if(!textarea)return
-const codeBlockBody=buildMarkdownCodeFence(text)
-if(!codeBlockBody)return
-const cursorPos=textarea.selectionStart||0
-const currentText=textarea.value||''
-const textBefore=currentText.substring(0,cursorPos)
-const textAfter=currentText.substring(cursorPos)
-const needsLeadingNewline=cursorPos>0&&!textBefore.endsWith('\n')
-const needsTrailingNewline=textAfter.length>0&&!textAfter.startsWith('\n')
-const codeBlock=`${needsLeadingNewline ? '\n' : ''}${codeBlockBody}${needsTrailingNewline ? '\n' : ''}`
-textarea.value=textBefore+codeBlock+textAfter
-const newCursorPos=textBefore.length+codeBlock.length
-textarea.setSelectionRange(newCursorPos,newCursorPos)
-textarea.focus()}
-function getClipboardFailureHint(error){try{if(!window.isSecureContext){return'当前页面为 HTTP（非安全上下文），浏览器可能禁止读取剪贴板。请在下方手动粘贴代码。'}
-const name=error&&error.name?String(error.name):''
-if(name==='NotAllowedError'){return'浏览器拒绝读取剪贴板（可能需要权限或仅允许 HTTPS）。请在下方手动粘贴代码。'}
-if(name==='NotFoundError'){return'未读取到剪贴板内容。请在下方手动粘贴代码。'}
-if(name==='Error'&&error&&error.message==='ClipboardReadTimeout'){return'浏览器没有及时返回剪贴板内容。请在下方手动粘贴代码。'}
-if(name==='Error'&&error&&error.message==='ClipboardEmpty'){return'未检测到可插入的剪贴板文本。请在下方手动粘贴代码。'}}catch(e){}
-return'由于浏览器安全限制无法自动读取剪贴板，请在下方手动粘贴代码。'}
-function openCodePasteModal(error){const panel=document.getElementById('code-paste-panel')
-const textarea=document.getElementById('code-paste-textarea')
-const hint=document.getElementById('code-paste-hint')
-if(!panel||!textarea){showStatus('无法读取剪贴板，请手动粘贴代码','error')
-return}
-if(hint){hint.textContent=getClipboardFailureHint(error)}
-textarea.value=''
-panel.classList.remove('hidden')
-panel.classList.add('show')
-setTimeout(()=>{try{textarea.focus()}catch(e){}},0)
-document.addEventListener('keydown',handleCodePasteModalKeydown)}
-function closeCodePasteModal(){const panel=document.getElementById('code-paste-panel')
-const textarea=document.getElementById('code-paste-textarea')
-if(!panel)return
-panel.classList.remove('show')
-panel.classList.add('hidden')
-if(textarea){textarea.value=''}
-document.removeEventListener('keydown',handleCodePasteModalKeydown)}
-function handleCodePasteModalKeydown(event){if(event.key==='Escape'){closeCodePasteModal()}}
-async function submitFeedback(){const feedbackText=document.getElementById('feedback-text').value.trim()
-const selectedOptions=[]
-const optionsContainer=document.getElementById('options-container')
-if(optionsContainer){const checkboxes=optionsContainer.querySelectorAll('input[type="checkbox"]:checked')
-checkboxes.forEach(checkbox=>{if(checkbox.value){selectedOptions.push(checkbox.value)}})}
-if(!feedbackText&&selectedOptions.length===0&&selectedImages.length===0){showStatus('请输入反馈内容、选择预定义选项或上传图片','error')
-return}
-try{const submitBtn=document.getElementById('submit-btn')
-submitBtn.disabled=true
-submitBtn.innerHTML='提交中...'
-const formData=new FormData()
-formData.append('feedback_text',feedbackText)
-formData.append('selected_options',JSON.stringify(selectedOptions))
-selectedImages.forEach((img,index)=>{if(img.file){formData.append(`image_${index}`,img.file)}})
-const currentTaskId=window.activeTaskId
-const submitUrl=currentTaskId?`/api/tasks/${currentTaskId}/submit`:'/api/submit'
-console.log(`使用提交端点: ${submitUrl}`)
-const response=await fetch(submitUrl,{method:'POST',body:formData})
-const result=await response.json()
-if(response.ok){showStatus(result.message,'success')
-document.getElementById('feedback-text').value=''
-document.querySelectorAll('input[type="checkbox"]').forEach(cb=>(cb.checked=false))
-clearAllImages()
-if(currentTaskId){if(typeof taskTextareaContents!=='undefined'){delete taskTextareaContents[currentTaskId]}
-if(typeof taskOptionsStates!=='undefined'){delete taskOptionsStates[currentTaskId]}
-if(typeof taskImages!=='undefined'){delete taskImages[currentTaskId]}}
-if(typeof refreshTasksList==='function'){console.log('调用 refreshTasksList 刷新任务列表...')
-await refreshTasksList()}else{if(config){config.has_content=false
-console.log('反馈提交后，本地状态已更新为无内容')}
-showNoContentPage()}}else{showStatus(result.message||'提交失败','error')}}catch(error){console.error('提交失败:',error)
-showStatus('网络错误，请重试','error')}finally{const submitBtn=document.getElementById('submit-btn')
-submitBtn.disabled=false
-submitBtn.innerHTML=`
+    `
+  } catch (e) {
+    // 最后兜底：极端情况下显示文本提示，避免再退化为 emoji
+    container.textContent = '等待中'
+  }
+}
+
+/**
+ * 初始化嫩芽生长 Lottie 动画
+ *
+ * 生命周期：
+ *   1. 检查容器元素是否存在
+ *   2. 检查 Lottie 库是否已加载
+ *   3. 销毁已有动画（防止内存泄漏）
+ *   4. 创建新动画实例
+ *   5. 监听加载完成事件，应用主题颜色
+ *   6. 监听错误事件，显示降级图标
+ */
+function initHourglassAnimation() {
+  const container = document.getElementById('hourglass-lottie')
+  if (!container) {
+    console.warn('动画容器未找到')
+    return
+  }
+
+  // 检查 Lottie 库是否已通过 <script defer> 加载
+  if (typeof lottie === 'undefined') {
+    console.warn('Lottie 库未加载，显示备用图标')
+    renderSproutFallback(container)
+    return
+  }
+
+  try {
+    // 销毁旧动画实例（防止内存泄漏和重复动画）
+    if (hourglassAnimation) {
+      hourglassAnimation.destroy()
+    }
+
+    // 创建嫩芽生长动画
+    hourglassAnimation = lottie.loadAnimation({
+      container: container,
+      renderer: 'svg', // 使用 SVG 渲染器（高质量缩放）
+      loop: true, // 循环播放
+      autoplay: true, // 自动开始播放
+      path: '/static/lottie/sprout.json', // 动画 JSON 文件路径
+      rendererSettings: {
+        preserveAspectRatio: 'xMidYMid meet' // 保持宽高比，居中显示
+      }
+    })
+
+    // 动画加载完成后，根据当前主题更新线条颜色
+    hourglassAnimation.addEventListener('DOMLoaded', () => {
+      updateLottieAnimationColor()
+    })
+
+    // 动画加载错误处理（网络问题或 JSON 解析失败）
+    hourglassAnimation.addEventListener('error', () => {
+      console.warn('Lottie 动画加载失败，显示备用图标')
+      renderSproutFallback(container)
+    })
+
+    console.log('嫩芽动画初始化成功')
+  } catch (error) {
+    console.error('Lottie 动画初始化失败:', error)
+    renderSproutFallback(container) // 降级为 SVG/CSS 动画
+  }
+}
+
+/**
+ * 根据当前主题更新 Lottie 动画的线条颜色
+ *
+ * 实现方式：
+ *   使用 CSS filter: invert(1) 反转颜色，而非修改 SVG 内部属性。
+ *   这种方式更简单可靠，且能在主题切换时即时生效。
+ *
+ * 效果：
+ *   - invert(0) / none：保持原色
+ *   - invert(1)：将所有颜色反转（黑→白，白→黑）
+ */
+function updateLottieAnimationColor() {
+  const container = document.getElementById('hourglass-lottie')
+  if (!container) return
+
+  // 获取当前主题状态
+  const isLightTheme = document.documentElement.getAttribute('data-theme') === 'light'
+
+  // 应用 CSS filter 实现颜色切换
+  if (isLightTheme) {
+    // 浅色模式：保持原色（深色线条在浅色背景上清晰可见）
+    container.style.filter = 'none'
+  } else {
+    // 深色模式：反转颜色（深色线条变为白色，在深色背景上清晰可见）
+    container.style.filter = 'invert(1)'
+  }
+
+  console.log('Lottie 动画颜色已更新:', isLightTheme ? '浅色模式（原色）' : '深色模式（反转）')
+}
+
+// 监听主题变化事件（由 ThemeManager 在 theme.js 中派发）
+// 用于在用户切换主题时即时更新 Lottie 动画颜色
+window.addEventListener('theme-changed', event => {
+  console.log('主题变更事件:', event.detail)
+  // 延迟 50ms 执行，确保 DOM data-theme 属性已更新
+  setTimeout(updateLottieAnimationColor, 50)
+})
+
+// 高性能markdown渲染函数
+// isMarkdown: 是否为 Markdown 源文本（需要 marked.js 解析）
+function renderMarkdownContent(element, content, isMarkdown = false) {
+  // 使用requestAnimationFrame优化渲染时机
+  requestAnimationFrame(() => {
+    if (content) {
+      let htmlContent = content
+
+      // 如果是 Markdown 文本，先用 marked.js 解析
+      if (isMarkdown && typeof marked !== 'undefined') {
+        try {
+          htmlContent = marked.parse(content)
+        } catch (e) {
+          console.warn('marked.js 解析失败:', e)
+        }
+      }
+
+      // 批量DOM操作优化
+      const fragment = document.createDocumentFragment()
+      const tempDiv = document.createElement('div')
+      tempDiv.innerHTML = htmlContent
+
+      // 移动所有子节点到fragment
+      while (tempDiv.firstChild) {
+        fragment.appendChild(tempDiv.firstChild)
+      }
+
+      // 一次性更新DOM
+      element.innerHTML = ''
+      element.appendChild(fragment)
+
+      // 处理代码块，添加复制按钮
+      processCodeBlocks(element)
+
+      // 处理删除线语法
+      processStrikethrough(element)
+
+      /**
+       * 按需加载并渲染 MathJax 数学公式
+       *
+       * 加载策略：
+       *   1. 首先检测内容中是否包含数学公式（$...$, $$...$$, \(...\), \[...\]）
+       *   2. 如果有数学公式，触发 MathJax 懒加载（约 1.17MB）
+       *   3. MathJax 加载完成后，通过 startup.ready 回调自动渲染待处理元素
+       *
+       * 回退机制：
+       *   如果 loadMathJaxIfNeeded 未定义（理论上不会发生），
+       *   回退到直接检查 MathJax 对象并调用 typesetPromise
+       */
+      const textContent = element.textContent || ''
+      if (window.loadMathJaxIfNeeded) {
+        window.loadMathJaxIfNeeded(element, textContent)
+      } else if (window.MathJax && window.MathJax.typesetPromise) {
+        // 回退：如果 MathJax 已加载但 loadMathJaxIfNeeded 不可用，直接渲染
+        window.MathJax.typesetPromise([element]).catch(err => {
+          console.warn('MathJax 渲染失败:', err)
+        })
+      }
+    } else {
+      element.textContent = '加载中...'
+    }
+  })
+}
+
+// 处理代码块，添加复制按钮和语言标识
+function processCodeBlocks(container) {
+  const codeBlocks = container.querySelectorAll('pre')
+
+  codeBlocks.forEach(pre => {
+    // 检查是否已经被处理过
+    if (pre.parentElement && pre.parentElement.classList.contains('code-block-container')) {
+      return
+    }
+
+    // 创建代码块容器
+    const codeContainer = document.createElement('div')
+    codeContainer.className = 'code-block-container'
+
+    // 将 pre 元素包装在容器中
+    pre.parentNode.insertBefore(codeContainer, pre)
+    codeContainer.appendChild(pre)
+
+    // 检测语言类型
+    const codeElement = pre.querySelector('code')
+    let language = 'text'
+    if (codeElement && codeElement.className) {
+      const langMatch = codeElement.className.match(/language-(\w+)/)
+      if (langMatch) {
+        language = langMatch[1]
+      }
+    }
+
+    // 创建工具栏
+    const toolbar = document.createElement('div')
+    toolbar.className = 'code-toolbar'
+
+    // 添加语言标识
+    if (language !== 'text') {
+      const langLabel = document.createElement('span')
+      langLabel.className = 'language-label'
+      langLabel.textContent = language.toUpperCase()
+      toolbar.appendChild(langLabel)
+    }
+
+    // 使用安全的复制按钮创建方法
+    const copyButton = DOMSecurity.createCopyButton(pre.textContent || '')
+
+    toolbar.appendChild(copyButton)
+
+    // 将工具栏添加到容器中
+    codeContainer.appendChild(toolbar)
+  })
+}
+
+// 复制代码到剪贴板
+async function copyCodeToClipboard(preElement, button) {
+  // Claude 官方风格图标
+  const checkIconSvg =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" style="width: 14px; height: 14px; margin-right: 4px; vertical-align: middle;"><path fill-rule="evenodd" clip-rule="evenodd" d="M13.7803 4.21967C14.0732 4.51256 14.0732 4.98744 13.7803 5.28033L6.78033 12.2803C6.48744 12.5732 6.01256 12.5732 5.71967 12.2803L2.21967 8.78033C1.92678 8.48744 1.92678 8.01256 2.21967 7.71967C2.51256 7.42678 2.98744 7.42678 3.28033 7.71967L6.25 10.6893L12.7197 4.21967C13.0126 3.92678 13.4874 3.92678 13.7803 4.21967Z"/></svg>'
+  const errorIconSvg =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" style="width: 14px; height: 14px; margin-right: 4px; vertical-align: middle;"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.21967 4.21967C4.51256 3.92678 4.98744 3.92678 5.28033 4.21967L8 6.93934L10.7197 4.21967C11.0126 3.92678 11.4874 3.92678 11.7803 4.21967C12.0732 4.51256 12.0732 4.98744 11.7803 5.28033L9.06066 8L11.7803 10.7197C12.0732 11.0126 12.0732 11.4874 11.7803 11.7803C11.4874 12.0732 11.0126 12.0732 10.7197 11.7803L8 9.06066L5.28033 11.7803C4.98744 12.0732 4.51256 12.0732 4.21967 11.7803C3.92678 11.4874 3.92678 11.0126 4.21967 10.7197L6.93934 8L4.21967 5.28033C3.92678 4.98744 3.92678 4.51256 4.21967 4.21967Z"/></svg>'
+
+  try {
+    const codeElement = preElement.querySelector('code')
+    const textToCopy = codeElement ? codeElement.textContent : preElement.textContent
+
+    await navigator.clipboard.writeText(textToCopy)
+
+    // 更新按钮状态
+    const originalHTML = button.innerHTML
+    button.innerHTML = checkIconSvg + '已复制'
+    button.classList.add('copied')
+
+    // 2秒后恢复原状
+    setTimeout(() => {
+      button.innerHTML = originalHTML
+      button.classList.remove('copied')
+    }, 2000)
+  } catch (err) {
+    console.error('复制失败:', err)
+
+    // 显示错误状态
+    const originalHTML = button.innerHTML
+    button.innerHTML = errorIconSvg + '复制失败'
+    button.classList.add('error')
+
+    setTimeout(() => {
+      button.innerHTML = originalHTML
+      button.classList.remove('error')
+    }, 2000)
+  }
+}
+
+// 处理删除线语法 ~~text~~
+function processStrikethrough(container) {
+  // 获取所有文本节点，但排除代码块
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
+    acceptNode: function (node) {
+      // 排除代码块、pre、script 等标签内的文本
+      const parent = node.parentElement
+      if (
+        parent &&
+        (parent.tagName === 'CODE' ||
+          parent.tagName === 'PRE' ||
+          parent.tagName === 'SCRIPT' ||
+          parent.tagName === 'STYLE' ||
+          parent.closest('pre, code, script, style'))
+      ) {
+        return NodeFilter.FILTER_REJECT
+      }
+      return NodeFilter.FILTER_ACCEPT
+    }
+  })
+
+  const textNodes = []
+  let node
+  while ((node = walker.nextNode())) {
+    textNodes.push(node)
+  }
+
+  // 处理每个文本节点
+  textNodes.forEach(textNode => {
+    const text = textNode.textContent
+    // 匹配 ~~删除线~~ 语法，但不匹配代码块中的
+    const strikethroughRegex = /~~([^~\n]+?)~~/g
+
+    if (strikethroughRegex.test(text)) {
+      const newHTML = text.replace(strikethroughRegex, '<del>$1</del>')
+
+      // 创建临时容器来解析 HTML
+      const tempDiv = document.createElement('div')
+      tempDiv.innerHTML = newHTML
+
+      // 替换文本节点
+      const fragment = document.createDocumentFragment()
+      while (tempDiv.firstChild) {
+        fragment.appendChild(tempDiv.firstChild)
+      }
+
+      textNode.parentNode.replaceChild(fragment, textNode)
+    }
+  })
+}
+
+// 加载配置
+async function loadConfig() {
+  try {
+    const response = await fetch('/api/config')
+    config = await response.json()
+
+    // 检查是否有有效内容
+    if (!config.has_content) {
+      showNoContentPage()
+      // 不再显示动态状态消息，只保留HTML中的固定文本
+      return
+    }
+
+    // 显示正常内容页面
+    showContentPage()
+
+    // 页面首次加载不发送通知，只在内容变化时通知
+
+    // 更新描述 - 使用高性能渲染函数
+    const descriptionElement = document.getElementById('description')
+    renderMarkdownContent(descriptionElement, config.prompt_html || config.prompt)
+
+    // 加载预定义选项
+    if (config.predefined_options && config.predefined_options.length > 0) {
+      const optionsContainer = document.getElementById('options-container')
+      const separator = document.getElementById('separator')
+
+      config.predefined_options.forEach((option, index) => {
+        const optionDiv = document.createElement('div')
+        optionDiv.className = 'option-item'
+
+        const checkbox = document.createElement('input')
+        checkbox.type = 'checkbox'
+        checkbox.id = `option-${index}`
+        checkbox.value = option
+
+        const label = document.createElement('label')
+        label.htmlFor = `option-${index}`
+        label.textContent = option
+
+        optionDiv.appendChild(checkbox)
+        optionDiv.appendChild(label)
+        optionsContainer.appendChild(optionDiv)
+      })
+
+      optionsContainer.style.display = 'block'
+      separator.style.display = 'block'
+    }
+  } catch (error) {
+    console.error('加载配置失败:', error)
+    showStatus('加载配置失败', 'error')
+    throw error // 重新抛出错误，让调用者知道加载失败
+  }
+}
+
+// 显示无内容页面
+function showNoContentPage() {
+  document.getElementById('content-container').style.display = 'none'
+  document.getElementById('no-content-container').style.display = 'flex'
+
+  // 添加无内容模式的CSS类，启用特殊布局
+  document.body.classList.add('no-content-mode')
+
+  // 隐藏任务标签栏（无内容时不需要显示）
+  const taskTabsContainer = document.getElementById('task-tabs-container')
+  if (taskTabsContainer) {
+    taskTabsContainer.classList.add('hidden')
+  }
+
+  // 显示关闭按钮，让用户可以关闭服务
+  if (config) {
+    document.getElementById('no-content-buttons').style.display = 'block'
+  }
+}
+
+// 显示内容页面
+function showContentPage() {
+  document.getElementById('content-container').style.display = 'block'
+  document.getElementById('no-content-container').style.display = 'none'
+
+  // 移除无内容模式的CSS类，恢复正常布局
+  document.body.classList.remove('no-content-mode')
+
+  // 任务标签栏的显示由 multi_task.js 的 renderTaskTabs() 控制
+  // 这里不需要手动显示，等待 renderTaskTabs() 根据任务数量决定
+
+  enableSubmitButton()
+}
+
+// 禁用提交按钮
+function disableSubmitButton() {
+  const submitBtn = document.getElementById('submit-btn')
+  const insertBtn = document.getElementById('insert-code-btn')
+  const feedbackText = document.getElementById('feedback-text')
+
+  if (submitBtn) {
+    submitBtn.disabled = true
+    submitBtn.style.backgroundColor = '#3a3a3c'
+    submitBtn.style.color = '#8e8e93'
+    submitBtn.style.cursor = 'not-allowed'
+  }
+  if (insertBtn) {
+    insertBtn.disabled = true
+    insertBtn.style.backgroundColor = '#3a3a3c'
+    insertBtn.style.color = '#8e8e93'
+    insertBtn.style.cursor = 'not-allowed'
+  }
+  if (feedbackText) {
+    feedbackText.disabled = true
+    feedbackText.style.backgroundColor = '#2c2c2e'
+    feedbackText.style.color = '#8e8e93'
+    feedbackText.style.cursor = 'not-allowed'
+  }
+}
+
+// 启用提交按钮
+function enableSubmitButton() {
+  const submitBtn = document.getElementById('submit-btn')
+  const insertBtn = document.getElementById('insert-code-btn')
+  const feedbackText = document.getElementById('feedback-text')
+
+  if (submitBtn) {
+    submitBtn.disabled = false
+    submitBtn.style.backgroundColor = '#0a84ff'
+    submitBtn.style.color = '#ffffff'
+    submitBtn.style.cursor = 'pointer'
+  }
+  if (insertBtn) {
+    insertBtn.disabled = false
+    insertBtn.style.backgroundColor = '#48484a'
+    insertBtn.style.color = '#ffffff'
+    insertBtn.style.cursor = 'pointer'
+  }
+  if (feedbackText) {
+    feedbackText.disabled = false
+    feedbackText.style.backgroundColor = 'rgba(255, 255, 255, 0.03)'
+    feedbackText.style.color = '#f5f5f7'
+    feedbackText.style.cursor = 'text'
+  }
+}
+
+// 显示状态消息
+function showStatus(message, type) {
+  // 检查当前是否在无内容页面（使用 style.display 检查）
+  const noContentContainer = document.getElementById('no-content-container')
+  const isNoContentPage = noContentContainer && noContentContainer.style.display === 'flex'
+
+  // 🚫 在有内容时，只显示错误消息，跳过成功/信息提示
+  if (!isNoContentPage && type !== 'error') {
+    console.log(`[showStatus] 跳过非错误提示: ${message} (${type})`)
+    return
+  }
+
+  const statusElement = isNoContentPage
+    ? document.getElementById('no-content-status-message')
+    : document.getElementById('status-message')
+
+  if (!statusElement) return
+
+  statusElement.textContent = message
+  statusElement.className = `status-message status-${type}`
+  statusElement.style.display = 'block'
+
+  if (type === 'success') {
+    setTimeout(() => {
+      statusElement.style.display = 'none'
+    }, 3000)
+  }
+}
+
+// 插入代码功能 - 与GUI版本逻辑完全一致
+async function insertCodeFromClipboard() {
+  // iOS/Safari/HTTP 等环境可能无法使用 navigator.clipboard.readText()
+  // 因此这里采用“优先读取剪贴板 -> 失败则弹出粘贴输入框”的策略
+  let finished = false
+  let fallbackTimer = null
+
+  const finish = () => {
+    finished = true
+    if (fallbackTimer) {
+      clearTimeout(fallbackTimer)
+      fallbackTimer = null
+    }
+  }
+
+  fallbackTimer = setTimeout(() => {
+    if (finished) return
+    finish()
+    openCodePasteModal(new Error('ClipboardReadTimeout'))
+  }, 1500)
+
+  try {
+    if (!navigator.clipboard || typeof navigator.clipboard.readText !== 'function') {
+      finish()
+      openCodePasteModal()
+      return
+    }
+
+    const text = await navigator.clipboard.readText()
+    if (finished) return
+    finish()
+
+    if (!text || !text.trim()) {
+      openCodePasteModal(new Error('ClipboardEmpty'))
+      return
+    }
+
+    insertCodeBlockIntoFeedbackTextarea(text)
+    showStatus('代码已插入', 'success')
+  } catch (error) {
+    if (finished) return
+    finish()
+    console.error('读取剪贴板失败:', error)
+    openCodePasteModal(error)
+  }
+}
+
+function buildMarkdownCodeFence(text, lang = '') {
+  const normalizedText = String(text || '').replace(/\r\n?/g, '\n')
+  if (!normalizedText.trim()) return null
+
+  const backtickRuns = normalizedText.match(/`+/g) || []
+  const longestRun = backtickRuns.reduce((max, run) => Math.max(max, run.length), 0)
+  const fence = '`'.repeat(Math.max(3, longestRun + 1))
+  const fenceHead = lang ? `${fence}${lang}` : fence
+  const codeBody = normalizedText.endsWith('\n') ? normalizedText : `${normalizedText}\n`
+
+  return `${fenceHead}\n${codeBody}${fence}`
+}
+
+function insertCodeBlockIntoFeedbackTextarea(text) {
+  const textarea = document.getElementById('feedback-text')
+  if (!textarea) return
+
+  const codeBlockBody = buildMarkdownCodeFence(text)
+  if (!codeBlockBody) return
+
+  const cursorPos = textarea.selectionStart || 0
+  const currentText = textarea.value || ''
+  const textBefore = currentText.substring(0, cursorPos)
+  const textAfter = currentText.substring(cursorPos)
+  const needsLeadingNewline = cursorPos > 0 && !textBefore.endsWith('\n')
+  const needsTrailingNewline = textAfter.length > 0 && !textAfter.startsWith('\n')
+  const codeBlock =
+    `${needsLeadingNewline ? '\n' : ''}${codeBlockBody}${needsTrailingNewline ? '\n' : ''}`
+
+  // 插入代码块
+  textarea.value = textBefore + codeBlock + textAfter
+
+  // 将光标移动到代码块末尾（与GUI版本一致）
+  const newCursorPos = textBefore.length + codeBlock.length
+  textarea.setSelectionRange(newCursorPos, newCursorPos)
+  textarea.focus()
+}
+
+function getClipboardFailureHint(error) {
+  // 针对常见失败原因给出更明确的提示（尤其是 iOS/HTTP/权限）
+  try {
+    if (!window.isSecureContext) {
+      return '当前页面为 HTTP（非安全上下文），浏览器可能禁止读取剪贴板。请在下方手动粘贴代码。'
+    }
+
+    const name = error && error.name ? String(error.name) : ''
+    if (name === 'NotAllowedError') {
+      return '浏览器拒绝读取剪贴板（可能需要权限或仅允许 HTTPS）。请在下方手动粘贴代码。'
+    }
+    if (name === 'NotFoundError') {
+      return '未读取到剪贴板内容。请在下方手动粘贴代码。'
+    }
+    if (name === 'Error' && error && error.message === 'ClipboardReadTimeout') {
+      return '浏览器没有及时返回剪贴板内容。请在下方手动粘贴代码。'
+    }
+    if (name === 'Error' && error && error.message === 'ClipboardEmpty') {
+      return '未检测到可插入的剪贴板文本。请在下方手动粘贴代码。'
+    }
+  } catch (e) {
+    // ignore
+  }
+  return '由于浏览器安全限制无法自动读取剪贴板，请在下方手动粘贴代码。'
+}
+
+function openCodePasteModal(error) {
+  const panel = document.getElementById('code-paste-panel')
+  const textarea = document.getElementById('code-paste-textarea')
+  const hint = document.getElementById('code-paste-hint')
+
+  if (!panel || !textarea) {
+    showStatus('无法读取剪贴板，请手动粘贴代码', 'error')
+    return
+  }
+
+  if (hint) {
+    hint.textContent = getClipboardFailureHint(error)
+  }
+
+  textarea.value = ''
+  panel.classList.remove('hidden')
+  panel.classList.add('show')
+
+  // iOS 上需要在用户手势链路内尽快 focus，才能弹出键盘与“粘贴”菜单
+  setTimeout(() => {
+    try {
+      textarea.focus()
+    } catch (e) {
+      // ignore
+    }
+  }, 0)
+
+  // ESC 关闭（对齐图片模态框行为）
+  document.addEventListener('keydown', handleCodePasteModalKeydown)
+}
+
+function closeCodePasteModal() {
+  const panel = document.getElementById('code-paste-panel')
+  const textarea = document.getElementById('code-paste-textarea')
+  if (!panel) return
+
+  panel.classList.remove('show')
+  panel.classList.add('hidden')
+
+  if (textarea) {
+    textarea.value = ''
+  }
+
+  document.removeEventListener('keydown', handleCodePasteModalKeydown)
+}
+
+function handleCodePasteModalKeydown(event) {
+  if (event.key === 'Escape') {
+    closeCodePasteModal()
+  }
+}
+
+// 提交反馈
+async function submitFeedback() {
+  const feedbackText = document.getElementById('feedback-text').value.trim()
+  const selectedOptions = []
+
+  // 【修复】直接从 DOM 获取选中的预定义选项
+  // 不再依赖 config.predefined_options，因为在多任务模式下切换任务时 config 可能未同步更新
+  const optionsContainer = document.getElementById('options-container')
+  if (optionsContainer) {
+    const checkboxes = optionsContainer.querySelectorAll('input[type="checkbox"]:checked')
+    checkboxes.forEach(checkbox => {
+      // 使用 checkbox 的 value 属性获取选项文本
+      if (checkbox.value) {
+        selectedOptions.push(checkbox.value)
+      }
+    })
+  }
+
+  if (!feedbackText && selectedOptions.length === 0 && selectedImages.length === 0) {
+    // 如果没有任何输入，显示错误信息
+    showStatus('请输入反馈内容、选择预定义选项或上传图片', 'error')
+    return
+  }
+
+  try {
+    const submitBtn = document.getElementById('submit-btn')
+    submitBtn.disabled = true
+    submitBtn.innerHTML = '提交中...'
+
+    // 使用 FormData 上传文件，避免 base64 编码
+    const formData = new FormData()
+    formData.append('feedback_text', feedbackText)
+    formData.append('selected_options', JSON.stringify(selectedOptions))
+
+    // 添加图片文件（直接使用原始文件，不需要base64）
+    selectedImages.forEach((img, index) => {
+      if (img.file) {
+        formData.append(`image_${index}`, img.file)
+      }
+    })
+
+    // 获取当前活动任务ID（由 multi_task.js 管理）
+    const currentTaskId = window.activeTaskId
+
+    // 优先使用多任务提交端点（如果有活动任务）
+    const submitUrl = currentTaskId ? `/api/tasks/${currentTaskId}/submit` : '/api/submit'
+    console.log(`使用提交端点: ${submitUrl}`)
+
+    const response = await fetch(submitUrl, {
+      method: 'POST',
+      body: formData // 不设置 Content-Type，让浏览器自动设置 multipart/form-data
+    })
+
+    const result = await response.json()
+
+    if (response.ok) {
+      showStatus(result.message, 'success')
+
+      // 反馈提交成功，不需要通知（用户要求）
+
+      // 清空表单
+      document.getElementById('feedback-text').value = ''
+      // 取消选中所有复选框
+      document.querySelectorAll('input[type="checkbox"]').forEach(cb => (cb.checked = false))
+      // 清除所有图片
+      clearAllImages()
+
+      // 清理该任务的缓存（如果是多任务模式）
+      if (currentTaskId) {
+        if (typeof taskTextareaContents !== 'undefined') {
+          delete taskTextareaContents[currentTaskId]
+        }
+        if (typeof taskOptionsStates !== 'undefined') {
+          delete taskOptionsStates[currentTaskId]
+        }
+        if (typeof taskImages !== 'undefined') {
+          delete taskImages[currentTaskId]
+        }
+      }
+
+      // 立即刷新任务列表（由 multi_task.js 处理页面状态切换）
+      if (typeof refreshTasksList === 'function') {
+        console.log('调用 refreshTasksList 刷新任务列表...')
+        await refreshTasksList()
+      } else {
+        // 兼容旧模式：如果没有多任务支持，显示无内容页面
+        if (config) {
+          config.has_content = false
+          console.log('反馈提交后，本地状态已更新为无内容')
+        }
+        showNoContentPage()
+      }
+    } else {
+      showStatus(result.message || '提交失败', 'error')
+    }
+  } catch (error) {
+    console.error('提交失败:', error)
+    showStatus('网络错误，请重试', 'error')
+  } finally {
+    const submitBtn = document.getElementById('submit-btn')
+    submitBtn.disabled = false
+    // Claude 风格发送图标（右箭头，简洁风格）
+    submitBtn.innerHTML = `
       <svg class="btn-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29289 3.29289C3.68342 2.90237 4.31658 2.90237 4.70711 3.29289L10.7071 9.29289C11.0976 9.68342 11.0976 10.3166 10.7071 10.7071L4.70711 16.7071C4.31658 17.0976 3.68342 17.0976 3.29289 16.7071C2.90237 16.3166 2.90237 15.6834 3.29289 15.2929L8.58579 10L3.29289 4.70711C2.90237 4.31658 2.90237 3.68342 3.29289 3.29289ZM9.29289 3.29289C9.68342 2.90237 10.3166 2.90237 10.7071 3.29289L16.7071 9.29289C17.0976 9.68342 17.0976 10.3166 16.7071 10.7071L10.7071 16.7071C10.3166 17.0976 9.68342 17.0976 9.29289 16.7071C8.90237 16.3166 8.90237 15.6834 9.29289 15.2929L14.5858 10L9.29289 4.70711C8.90237 4.31658 8.90237 3.68342 9.29289 3.29289Z"/>
       </svg>
       发送请求
-    `}}
-async function closeInterface(){try{showStatus('正在关闭服务...','info')
-stopContentPolling()
-const response=await fetch('/api/close',{method:'POST',headers:{'Content-Type':'application/json'}})
-const result=await response.json()
-if(response.ok){showStatus('服务已关闭，正在刷新页面...','success')}else{showStatus('关闭失败，正在刷新页面...','error')}}catch(error){console.error('关闭界面失败:',error)
-showStatus('关闭界面失败，正在刷新页面...','error')}
-setTimeout(()=>{refreshPageSafely()},2000)}
-function refreshPageSafely(){console.log('正在刷新页面...')
-try{window.location.reload()}catch(reloadError){console.error('页面刷新失败:',reloadError)
-try{window.location.href=window.location.origin}catch(redirectError){console.error('页面跳转失败:',redirectError)
-try{window.location.href='about:blank'}catch(blankError){console.error('所有页面操作都失败:',blankError)}}}}
-function stopContentPolling(){console.log('[app.js] stopContentPolling 被调用，但轮询已停用')}
-let selectedImages=[]
-class NotificationManager{constructor(){this.isSupported='Notification'in window
-this.permission=this.isSupported?Notification.permission:'denied'
-this.audioContext=null
-this.audioBuffers=new Map()
-this.config={enabled:true,webEnabled:true,soundEnabled:true,soundVolume:0.8,soundMute:false,autoRequestPermission:true,timeout:5000,icon:'/icons/icon.svg',mobileOptimized:true,mobileVibrate:true}
-this.init()}
-async init(){console.log('初始化通知管理器...')
-if(!this.isSupported){console.warn('浏览器不支持Web Notification API')
-return}
-if(this.config.autoRequestPermission&&this.permission==='default'){await this.requestPermission()}
-await this.initAudio()
-console.log('通知管理器初始化完成')}
-async requestPermission(){if(!this.isSupported){console.warn('浏览器不支持Web Notification API')
-return false}
-try{if(Notification.requestPermission.length===0){this.permission=await Notification.requestPermission()}else{this.permission=await new Promise(resolve=>{Notification.requestPermission(resolve)})}
-console.log(`通知权限状态: ${this.permission}`)
-return this.permission==='granted'}catch(error){console.error('请求通知权限失败:',error)
-return false}}
-async initAudio(){try{const AudioContextClass=window.AudioContext||window.webkitAudioContext||window.mozAudioContext
-if(!AudioContextClass){console.warn('浏览器不支持Web Audio API')
-return}
-this.audioContext=new AudioContextClass()
-await this.loadAudioFile('default','/sounds/deng[噔].mp3')
-console.log('音频系统初始化完成')}catch(error){console.warn('音频系统初始化失败:',error)
-this.config.soundEnabled=false}}
-async loadAudioFile(name,url){if(!this.audioContext)return false
-try{const response=await fetch(url)
-const arrayBuffer=await response.arrayBuffer()
-const audioBuffer=await this.audioContext.decodeAudioData(arrayBuffer)
-this.audioBuffers.set(name,audioBuffer)
-console.log(`音频文件加载成功: ${name}`)
-return true}catch(error){console.warn(`音频文件加载失败 ${name}:`,error)
-return false}}
-async showNotification(title,message,options={}){if(!this.config.enabled||!this.config.webEnabled){console.log('Web通知已禁用')
-return null}
-if(!this.isSupported){console.warn('浏览器不支持通知，使用降级方案')
-this.showFallbackNotification(title,message)
-return null}
-if(this.permission!=='granted'){console.warn('没有通知权限')
-if(this.config.autoRequestPermission){await this.requestPermission()
-if(this.permission!=='granted'){this.showFallbackNotification(title,message)
-return null}}else{this.showFallbackNotification(title,message)
-return null}}
-try{const notificationOptions={body:message,icon:options.icon||this.config.icon,badge:options.badge||this.config.icon,tag:options.tag||'ai-intervention-agent',requireInteraction:options.requireInteraction||false,silent:options.silent||false,...options}
-const notification=new Notification(title,notificationOptions)
-if(this.config.timeout>0){setTimeout(()=>{notification.close()},this.config.timeout)}
-notification.onclick=()=>{window.focus()
-notification.close()
-if(options.onClick){options.onClick()}}
-if(this.config.mobileVibrate&&'vibrate'in navigator){navigator.vibrate([200,100,200])}
-console.log('通知已显示:',title)
-return notification}catch(error){console.error('显示通知失败:',error)
-return null}}
-async playSound(soundName='default',volume=null,retryCount=0){if(!this.config.enabled||!this.config.soundEnabled||this.config.soundMute){console.log('声音通知已禁用')
-return false}
-if(!this.audioContext){console.warn('音频上下文未初始化，尝试降级方案')
-this.recordFallbackEvent('audio',{reason:'no_audio_context',soundName})
-return this.playSoundFallback(soundName)}
-if(this.audioContext.state==='suspended'){try{await this.audioContext.resume()
-console.log('音频上下文已恢复')}catch(error){console.warn('恢复音频上下文失败:',error)
-this.recordFallbackEvent('audio',{reason:'resume_failed',error:error.message,soundName})
-return this.playSoundFallback(soundName)}}
-const audioBuffer=this.audioBuffers.get(soundName)
-if(!audioBuffer){console.warn(`音频文件未找到: ${soundName}`)
-if(soundName!=='default'){console.log('尝试使用默认音频文件')
-return this.playSound('default',volume,retryCount)}
-this.recordFallbackEvent('audio',{reason:'buffer_not_found',soundName})
-return this.playSoundFallback(soundName)}
-try{const source=this.audioContext.createBufferSource()
-const gainNode=this.audioContext.createGain()
-source.buffer=audioBuffer
-source.connect(gainNode)
-gainNode.connect(this.audioContext.destination)
-const finalVolume=volume!==null?volume:this.config.soundVolume
-gainNode.gain.value=Math.max(0,Math.min(1,finalVolume))
-source.addEventListener('ended',()=>{console.log(`声音播放完成: ${soundName}`)})
-source.addEventListener('error',error=>{console.error('音频播放错误:',error)
-this.recordFallbackEvent('audio',{reason:'playback_error',error:error.message,soundName})})
-source.start(0)
-console.log(`播放声音: ${soundName}`)
-return true}catch(error){console.error('播放声音失败:',error)
-this.recordFallbackEvent('audio',{reason:'playback_failed',error:error.message,soundName})
-if(retryCount<2){console.log(`重试播放声音 (${retryCount + 1}/2): ${soundName}`)
-await new Promise(resolve=>setTimeout(resolve,500))
-return this.playSound(soundName,volume,retryCount+1)}
-return this.playSoundFallback(soundName)}}
-playSoundFallback(soundName){console.log(`使用音频降级方案: ${soundName}`)
-try{const audio=new Audio(`/sounds/${soundName === 'default' ? 'deng[噔].mp3' : soundName + '.mp3'}`)
-audio.volume=this.config.soundVolume
-const playPromise=audio.play()
-if(playPromise!==undefined){playPromise.then(()=>{console.log('HTML5 Audio播放成功')}).catch(error=>{console.warn('HTML5 Audio播放失败:',error)
-this.vibrateFallback()})}
-return true}catch(error){console.warn('HTML5 Audio降级失败:',error)
-return this.vibrateFallback()}}
-vibrateFallback(){if(this.config.mobileVibrate&&'vibrate'in navigator){try{navigator.vibrate([200,100,200])
-console.log('使用振动提醒')
-return true}catch(error){console.warn('振动提醒失败:',error)}}
-console.log('所有音频降级方案都失败了')
-return false}
-async sendNotification(title,message,options={}){const results=[]
-const promises=[]
-if(this.config.webEnabled){promises.push(this.showNotification(title,message,options).then(notification=>({type:'web',success:notification!==null})))}
-if(this.config.soundEnabled){promises.push(this.playSound(options.sound).then(soundSuccess=>({type:'sound',success:soundSuccess})))}
-if(promises.length>0){try{const promiseResults=await Promise.all(promises)
-results.push(...promiseResults)}catch(error){console.warn('通知执行过程中出现错误:',error)}}
-return results}
-showFallbackNotification(title,message,options={}){console.log(`降级通知: ${title} - ${message}`)
-if(typeof showStatus==='function'){showStatus(`${title}: ${message}`,'info')}
-this.flashTitle(title)
-if(!this.isSupported||this.permission==='denied'){this.showInPageNotification(title,message,options)}
-console.log(`%c🔔 ${title}`,'color: #0084ff; font-weight: bold; font-size: 14px;')
-console.log(`%c${message}`,'color: #666; font-size: 12px;')
-this.recordFallbackEvent('notification',{title,message,reason:options.reason||'unknown'})}
-flashTitle(message){const originalTitle=document.title
-let flashCount=0
-const maxFlashes=6
-const flashInterval=setInterval(()=>{document.title=flashCount%2===0?`🔔 ${message}`:originalTitle
-flashCount++
-if(flashCount>=maxFlashes){clearInterval(flashInterval)
-document.title=originalTitle}},1000)}
-updateConfig(newConfig){this.config={...this.config,...newConfig}
-console.log('通知配置已更新:',this.config)}
-getStatus(){return{supported:this.isSupported,permission:this.permission,audioContext:this.audioContext?this.audioContext.state:'unavailable',config:this.config}}
-showInPageNotification(title,message,options={}){const notification=DOMSecurity.createNotification(title,message)
-notification.style.cssText=`
+    `
+  }
+}
+
+// 关闭界面 - 简化版本，统一刷新逻辑
+async function closeInterface() {
+  try {
+    showStatus('正在关闭服务...', 'info')
+
+    // 停止轮询
+    stopContentPolling()
+
+    const response = await fetch('/api/close', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+
+    const result = await response.json()
+    if (response.ok) {
+      showStatus('服务已关闭，正在刷新页面...', 'success')
+    } else {
+      showStatus('关闭失败，正在刷新页面...', 'error')
+    }
+  } catch (error) {
+    console.error('关闭界面失败:', error)
+    showStatus('关闭界面失败，正在刷新页面...', 'error')
+  }
+
+  // 无论成功还是失败，都在2秒后刷新页面
+  setTimeout(() => {
+    refreshPageSafely()
+  }, 2000)
+}
+
+// 安全刷新页面函数
+function refreshPageSafely() {
+  console.log('正在刷新页面...')
+  try {
+    window.location.reload()
+  } catch (reloadError) {
+    console.error('页面刷新失败:', reloadError)
+    // 如果刷新失败，尝试跳转到根路径
+    try {
+      window.location.href = window.location.origin
+    } catch (redirectError) {
+      console.error('页面跳转失败:', redirectError)
+      // 最后的备选方案：跳转到空白页
+      try {
+        window.location.href = 'about:blank'
+      } catch (blankError) {
+        console.error('所有页面操作都失败:', blankError)
+      }
+    }
+  }
+}
+
+// ==================================================================
+// 内容轮询 - 已停用
+// ==================================================================
+//
+// 说明：
+//   内容轮询功能已完全由 multi_task.js 的任务轮询接管。
+//   此处仅保留空实现，防止被其他代码调用时报错。
+//
+// 历史原因：
+//   原设计中 app.js 负责轮询 /api/config 检测内容变化，
+//   但与 multi_task.js 的 /api/tasks 轮询存在冲突，
+//   导致 textarea 内容被意外清空。
+//
+// 解决方案：
+//   1. 停用 app.js 轮询，由 multi_task.js 统一管理
+//   2. multi_task.js 实现了实时保存机制
+// ==================================================================
+
+/**
+ * 停止内容轮询（空实现）
+ *
+ * 保留此函数是因为 closeInterface() 会调用它。
+ * 实际轮询由 multi_task.js 的 stopTasksPolling() 管理。
+ */
+function stopContentPolling() {
+  // 轮询已停用，此函数不执行任何操作
+  console.log('[app.js] stopContentPolling 被调用，但轮询已停用')
+}
+
+// updatePageContent() 已删除
+// 页面内容更新现在完全由 multi_task.js 的以下函数处理：
+//   - loadTaskDetails(): 加载任务详情
+//   - updateDescriptionDisplay(): 更新描述区域
+//   - updateOptionsDisplay(): 更新选项区域
+
+// ========== 图片处理功能 ==========
+
+// 图片管理数组
+let selectedImages = []
+
+// 通知管理系统
+class NotificationManager {
+  constructor() {
+    this.isSupported = 'Notification' in window
+    this.permission = this.isSupported ? Notification.permission : 'denied'
+    this.audioContext = null
+    this.audioBuffers = new Map()
+    this.serviceWorkerRegistration = null
+    this.initPromise = null
+    this.permissionRequestPromise = null
+    this.autoPermissionListenersBound = false
+    this.boundPermissionRequestHandler = null
+    this.config = {
+      enabled: true,
+      webEnabled: true,
+      soundEnabled: true,
+      soundVolume: 0.8,
+      soundMute: false,
+      autoRequestPermission: true,
+      timeout: 5000,
+      icon: '/icons/icon.svg',
+      mobileOptimized: true,
+      mobileVibrate: true
+    }
+  }
+
+  async init() {
+    if (this.initPromise) {
+      return this.initPromise
+    }
+
+    this.initPromise = (async () => {
+      console.log('初始化通知管理器...')
+      this.syncPermissionState()
+
+      if (!this.isSupported) {
+        console.warn('浏览器不支持 Web Notification API')
+      } else {
+        await this.registerServiceWorker()
+        this.bindAutoPermissionRequest()
+      }
+
+      await this.initAudio()
+      console.log('通知管理器初始化完成')
+    })()
+
+    return this.initPromise
+  }
+
+  syncPermissionState() {
+    this.permission = this.isSupported ? Notification.permission : 'denied'
+    return this.permission
+  }
+
+  supportsServiceWorkerNotifications() {
+    return (
+      typeof navigator !== 'undefined' &&
+      'serviceWorker' in navigator &&
+      window.isSecureContext
+    )
+  }
+
+  async registerServiceWorker() {
+    if (!this.supportsServiceWorkerNotifications()) {
+      if (!window.isSecureContext) {
+        console.warn('当前不是安全上下文，无法注册通知 service worker')
+      }
+      return null
+    }
+
+    if (this.serviceWorkerRegistration) {
+      return this.serviceWorkerRegistration
+    }
+
+    try {
+      await navigator.serviceWorker.register('/notification-service-worker.js')
+      this.serviceWorkerRegistration = await navigator.serviceWorker.ready
+      console.log('通知 service worker 已注册')
+      return this.serviceWorkerRegistration
+    } catch (error) {
+      console.warn('通知 service worker 注册失败:', error)
+      return null
+    }
+  }
+
+  bindAutoPermissionRequest() {
+    if (!this.isSupported) return
+
+    if (!this.config.autoRequestPermission || this.syncPermissionState() !== 'default') {
+      this.removeAutoPermissionRequestListeners()
+      return
+    }
+
+    if (this.autoPermissionListenersBound) {
+      return
+    }
+
+    this.boundPermissionRequestHandler = () => {
+      if (!this.config.autoRequestPermission) {
+        this.removeAutoPermissionRequestListeners()
+        return
+      }
+
+      if (this.syncPermissionState() !== 'default') {
+        this.removeAutoPermissionRequestListeners()
+        return
+      }
+
+      this.requestPermission({ requireUserGesture: false }).finally(() => {
+        if (this.syncPermissionState() !== 'default') {
+          this.removeAutoPermissionRequestListeners()
+        }
+      })
+    }
+
+    ;['click', 'keydown', 'touchstart'].forEach(eventName => {
+      document.addEventListener(eventName, this.boundPermissionRequestHandler, {
+        once: true,
+        passive: true
+      })
+    })
+
+    this.autoPermissionListenersBound = true
+  }
+
+  removeAutoPermissionRequestListeners() {
+    if (!this.autoPermissionListenersBound || !this.boundPermissionRequestHandler) {
+      return
+    }
+
+    ;['click', 'keydown', 'touchstart'].forEach(eventName => {
+      document.removeEventListener(eventName, this.boundPermissionRequestHandler)
+    })
+
+    this.autoPermissionListenersBound = false
+    this.boundPermissionRequestHandler = null
+  }
+
+  async requestPermission({ requireUserGesture = true } = {}) {
+    if (!this.isSupported) {
+      console.warn('浏览器不支持 Web Notification API')
+      return false
+    }
+
+    this.syncPermissionState()
+    if (this.permission === 'granted') {
+      return true
+    }
+
+    if (this.permission === 'denied') {
+      return false
+    }
+
+    if (
+      requireUserGesture &&
+      navigator.userActivation &&
+      navigator.userActivation.isActive === false
+    ) {
+      console.warn('通知权限请求需要用户操作，已延迟到下一次交互')
+      this.bindAutoPermissionRequest()
+      return false
+    }
+
+    if (this.permissionRequestPromise) {
+      return this.permissionRequestPromise
+    }
+
+    try {
+      this.permissionRequestPromise = (async () => {
+        if (Notification.requestPermission.length === 0) {
+          this.permission = await Notification.requestPermission()
+        } else {
+          this.permission = await new Promise(resolve => {
+            Notification.requestPermission(resolve)
+          })
+        }
+
+        console.log(`通知权限状态: ${this.permission}`)
+        return this.permission === 'granted'
+      })()
+
+      return await this.permissionRequestPromise
+    } catch (error) {
+      console.error('请求通知权限失败:', error)
+      return false
+    } finally {
+      this.permissionRequestPromise = null
+      if (this.permission !== 'default') {
+        this.removeAutoPermissionRequestListeners()
+      }
+    }
+  }
+
+  async initAudio() {
+    try {
+      // 检查浏览器音频支持
+      const AudioContextClass =
+        window.AudioContext || window.webkitAudioContext || window.mozAudioContext
+      if (!AudioContextClass) {
+        console.warn('浏览器不支持Web Audio API')
+        return
+      }
+
+      // 创建音频上下文（需要用户交互后才能启用）
+      this.audioContext = new AudioContextClass()
+
+      // 预加载默认音频文件
+      await this.loadAudioFile('default', '/sounds/deng[噔].mp3')
+
+      console.log('音频系统初始化完成')
+    } catch (error) {
+      console.warn('音频系统初始化失败:', error)
+      // 降级：禁用音频功能
+      this.config.soundEnabled = false
+    }
+  }
+
+  async loadAudioFile(name, url) {
+    if (!this.audioContext) return false
+
+    try {
+      const response = await fetch(url)
+      const arrayBuffer = await response.arrayBuffer()
+      const audioBuffer = await this.audioContext.decodeAudioData(arrayBuffer)
+      this.audioBuffers.set(name, audioBuffer)
+      console.log(`音频文件加载成功: ${name}`)
+      return true
+    } catch (error) {
+      console.warn(`音频文件加载失败 ${name}:`, error)
+      return false
+    }
+  }
+
+  async showNotification(title, message, options = {}) {
+    if (!this.config.enabled || !this.config.webEnabled) {
+      console.log('Web 通知已禁用')
+      return null
+    }
+
+    if (!this.isSupported) {
+      console.warn('浏览器不支持通知，使用降级方案')
+      this.showFallbackNotification(title, message, { ...options, reason: 'unsupported' })
+      return null
+    }
+
+    this.syncPermissionState()
+    if (this.permission !== 'granted') {
+      console.warn('当前没有系统通知权限')
+      if (this.config.autoRequestPermission) {
+        const granted = await this.requestPermission({
+          requireUserGesture: !(navigator.userActivation && navigator.userActivation.isActive)
+        })
+        if (!granted) {
+          this.showFallbackNotification(title, message, {
+            ...options,
+            reason: this.permission === 'denied' ? 'permission_denied' : 'permission_default'
+          })
+          return null
+        }
+      } else {
+        this.showFallbackNotification(title, message, {
+          ...options,
+          reason: 'permission_disabled'
+        })
+        return null
+      }
+    }
+
+    try {
+      const {
+        onClick,
+        url,
+        data: extraData,
+        icon,
+        badge,
+        tag,
+        requireInteraction,
+        silent,
+        ...restOptions
+      } = options
+
+      const notificationOptions = {
+        body: message,
+        icon: icon || this.config.icon,
+        badge: badge || this.config.icon,
+        tag: tag || 'ai-intervention-agent',
+        requireInteraction: requireInteraction || false,
+        silent: silent || false,
+        data: {
+          url: url || window.location.href,
+          ...extraData
+        },
+        ...restOptions
+      }
+
+      const notification = await this.showSystemNotification(
+        title,
+        notificationOptions,
+        { ...restOptions, onClick }
+      )
+
+      if (!notification) {
+        this.showFallbackNotification(title, message, {
+          ...options,
+          reason: 'system_notification_failed'
+        })
+        return null
+      }
+
+      console.log('系统通知已显示:', title)
+      return notification
+    } catch (error) {
+      console.error('显示通知失败:', error)
+      this.showFallbackNotification(title, message, {
+        ...options,
+        reason: 'show_notification_exception'
+      })
+      return null
+    }
+  }
+
+  async showSystemNotification(title, notificationOptions, options = {}) {
+    const registration = await this.registerServiceWorker()
+    if (registration && typeof registration.showNotification === 'function') {
+      try {
+        await registration.showNotification(title, notificationOptions)
+        return {
+          close() {}
+        }
+      } catch (error) {
+        console.warn('通过 service worker 显示通知失败，回退到页面 Notification:', error)
+      }
+    }
+
+    try {
+      const notification = new Notification(title, notificationOptions)
+
+      // 设置超时自动关闭
+      if (this.config.timeout > 0) {
+        setTimeout(() => {
+          notification.close()
+        }, this.config.timeout)
+      }
+
+      // 点击事件处理
+      notification.onclick = () => {
+        window.focus()
+        notification.close()
+        if (options.onClick) {
+          options.onClick()
+        }
+      }
+
+      // 移动设备震动
+      if (this.config.mobileVibrate && 'vibrate' in navigator) {
+        navigator.vibrate([200, 100, 200])
+      }
+
+      return notification
+    } catch (error) {
+      console.error('页面 Notification 创建失败:', error)
+      return null
+    }
+  }
+
+  async playSound(soundName = 'default', volume = null, retryCount = 0) {
+    if (!this.config.enabled || !this.config.soundEnabled || this.config.soundMute) {
+      console.log('声音通知已禁用')
+      return false
+    }
+
+    if (!this.audioContext) {
+      console.warn('音频上下文未初始化，尝试降级方案')
+      this.recordFallbackEvent('audio', { reason: 'no_audio_context', soundName })
+      return this.playSoundFallback(soundName)
+    }
+
+    // 恢复音频上下文（如果被暂停）
+    if (this.audioContext.state === 'suspended') {
+      try {
+        await this.audioContext.resume()
+        console.log('音频上下文已恢复')
+      } catch (error) {
+        console.warn('恢复音频上下文失败:', error)
+        this.recordFallbackEvent('audio', {
+          reason: 'resume_failed',
+          error: error.message,
+          soundName
+        })
+        return this.playSoundFallback(soundName)
+      }
+    }
+
+    const audioBuffer = this.audioBuffers.get(soundName)
+    if (!audioBuffer) {
+      console.warn(`音频文件未找到: ${soundName}`)
+      // 尝试加载默认音频文件
+      if (soundName !== 'default') {
+        console.log('尝试使用默认音频文件')
+        return this.playSound('default', volume, retryCount)
+      }
+      this.recordFallbackEvent('audio', { reason: 'buffer_not_found', soundName })
+      return this.playSoundFallback(soundName)
+    }
+
+    try {
+      const source = this.audioContext.createBufferSource()
+      const gainNode = this.audioContext.createGain()
+
+      source.buffer = audioBuffer
+      source.connect(gainNode)
+      gainNode.connect(this.audioContext.destination)
+
+      // 设置音量
+      const finalVolume = volume !== null ? volume : this.config.soundVolume
+      gainNode.gain.value = Math.max(0, Math.min(1, finalVolume))
+
+      // 添加错误处理
+      source.addEventListener('ended', () => {
+        console.log(`声音播放完成: ${soundName}`)
+      })
+
+      source.addEventListener('error', error => {
+        console.error('音频播放错误:', error)
+        this.recordFallbackEvent('audio', {
+          reason: 'playback_error',
+          error: error.message,
+          soundName
+        })
+      })
+
+      source.start(0)
+      console.log(`播放声音: ${soundName}`)
+      return true
+    } catch (error) {
+      console.error('播放声音失败:', error)
+      this.recordFallbackEvent('audio', {
+        reason: 'playback_failed',
+        error: error.message,
+        soundName
+      })
+
+      // 重试机制
+      if (retryCount < 2) {
+        console.log(`重试播放声音 (${retryCount + 1}/2): ${soundName}`)
+        await new Promise(resolve => setTimeout(resolve, 500)) // 等待500ms后重试
+        return this.playSound(soundName, volume, retryCount + 1)
+      }
+
+      // 重试失败，使用降级方案
+      return this.playSoundFallback(soundName)
+    }
+  }
+
+  playSoundFallback(soundName) {
+    // 音频播放降级方案
+    console.log(`使用音频降级方案: ${soundName}`)
+
+    try {
+      // 方案1: 尝试使用HTML5 Audio元素
+      const audio = new Audio(
+        `/sounds/${soundName === 'default' ? 'deng[噔].mp3' : soundName + '.mp3'}`
+      )
+      audio.volume = this.config.soundVolume
+
+      const playPromise = audio.play()
+      if (playPromise !== undefined) {
+        playPromise
+          .then(() => {
+            console.log('HTML5 Audio播放成功')
+          })
+          .catch(error => {
+            console.warn('HTML5 Audio播放失败:', error)
+            // 方案2: 使用振动API（移动设备）
+            this.vibrateFallback()
+          })
+      }
+      return true
+    } catch (error) {
+      console.warn('HTML5 Audio降级失败:', error)
+      // 方案2: 使用振动API（移动设备）
+      return this.vibrateFallback()
+    }
+  }
+
+  vibrateFallback() {
+    // 振动降级方案（移动设备）
+    if (this.config.mobileVibrate && 'vibrate' in navigator) {
+      try {
+        navigator.vibrate([200, 100, 200]) // 振动模式：200ms振动，100ms停止，200ms振动
+        console.log('使用振动提醒')
+        return true
+      } catch (error) {
+        console.warn('振动提醒失败:', error)
+      }
+    }
+
+    console.log('所有音频降级方案都失败了')
+    return false
+  }
+
+  async sendNotification(title, message, options = {}) {
+    const results = []
+
+    // 同时执行Web通知和音频播放，确保同步
+    const promises = []
+
+    // 显示Web通知
+    if (this.config.webEnabled) {
+      promises.push(
+        this.showNotification(title, message, options).then(notification => ({
+          type: 'web',
+          success: notification !== null
+        }))
+      )
+    }
+
+    // 播放声音
+    if (this.config.soundEnabled) {
+      promises.push(
+        this.playSound(options.sound).then(soundSuccess => ({
+          type: 'sound',
+          success: soundSuccess
+        }))
+      )
+    }
+
+    // 等待所有通知方式完成
+    if (promises.length > 0) {
+      try {
+        const promiseResults = await Promise.all(promises)
+        results.push(...promiseResults)
+      } catch (error) {
+        console.warn('通知执行过程中出现错误:', error)
+      }
+    }
+
+    return results
+  }
+
+  showFallbackNotification(title, message, options = {}) {
+    // 增强的降级方案：使用多种方式确保用户能收到通知
+    console.log(`降级通知: ${title} - ${message}`)
+
+    // 1. 尝试使用页面状态消息
+    if (typeof showStatus === 'function') {
+      showStatus(`${title}: ${message}`, 'info')
+    }
+
+    // 2. 尝试使用浏览器标题闪烁
+    this.flashTitle(title)
+
+    // 3. 尝试使用页面内弹窗（如果没有其他方式）
+    if (!this.isSupported || this.permission === 'denied') {
+      this.showInPageNotification(title, message, options)
+    }
+
+    // 4. 尝试使用控制台样式输出
+    console.log(`%c[通知] ${title}`, 'color: #0084ff; font-weight: bold; font-size: 14px;')
+    console.log(`%c${message}`, 'color: #666; font-size: 12px;')
+
+    // 5. 记录降级事件用于统计
+    this.recordFallbackEvent('notification', {
+      title,
+      message,
+      reason: options.reason || 'unknown'
+    })
+  }
+
+  flashTitle(message) {
+    // 标题闪烁提醒
+    const originalTitle = document.title
+    let flashCount = 0
+    const maxFlashes = 6
+
+    const flashInterval = setInterval(() => {
+      document.title = flashCount % 2 === 0 ? `[通知] ${message}` : originalTitle
+      flashCount++
+
+      if (flashCount >= maxFlashes) {
+        clearInterval(flashInterval)
+        document.title = originalTitle
+      }
+    }, 1000)
+  }
+
+  updateConfig(newConfig) {
+    this.config = { ...this.config, ...newConfig }
+    this.syncPermissionState()
+    this.bindAutoPermissionRequest()
+    console.log('通知配置已更新:', this.config)
+  }
+
+  getStatus() {
+    return {
+      supported: this.isSupported,
+      permission: this.permission,
+      serviceWorkerRegistered: Boolean(this.serviceWorkerRegistration),
+      audioContext: this.audioContext ? this.audioContext.state : 'unavailable',
+      config: this.config
+    }
+  }
+
+  showInPageNotification(title, message, options = {}) {
+    // 创建页面内通知元素
+    // 使用安全的通知创建方法
+    const notification = DOMSecurity.createNotification(title, message)
+
+    // 添加样式
+    notification.style.cssText = `
       position: fixed;
       top: 20px;
       right: 20px;
@@ -453,12 +1591,16 @@ notification.style.cssText=`
       color: #f5f5f7;
       font-family: inherit;
     `
-const titleEl=notification.querySelector('.in-page-notification-title')
-const messageEl=notification.querySelector('.in-page-notification-message')
-const closeEl=notification.querySelector('.in-page-notification-close')
-titleEl.style.cssText='font-weight: 600; margin-bottom: 0.5rem; font-size: 1rem;'
-messageEl.style.cssText='font-size: 0.9rem; line-height: 1.4; color: rgba(245, 245, 247, 0.8);'
-closeEl.style.cssText=`
+
+    // 添加内容样式
+    const titleEl = notification.querySelector('.in-page-notification-title')
+    const messageEl = notification.querySelector('.in-page-notification-message')
+    const closeEl = notification.querySelector('.in-page-notification-close')
+
+    titleEl.style.cssText = 'font-weight: 600; margin-bottom: 0.5rem; font-size: 1rem;'
+    messageEl.style.cssText =
+      'font-size: 0.9rem; line-height: 1.4; color: rgba(245, 245, 247, 0.8);'
+    closeEl.style.cssText = `
       position: absolute;
       top: 0.5rem;
       right: 0.5rem;
@@ -471,139 +1613,503 @@ closeEl.style.cssText=`
       border-radius: 4px;
       transition: all 0.2s ease;
     `
-document.body.appendChild(notification)
-closeEl.addEventListener('click',()=>{notification.style.transform='translateX(100%)'
-notification.style.opacity='0'
-setTimeout(()=>{if(notification.parentNode){notification.parentNode.removeChild(notification)}},300)})
-closeEl.addEventListener('mouseenter',()=>{closeEl.style.background='rgba(255, 255, 255, 0.1)'
-closeEl.style.color='#f5f5f7'})
-closeEl.addEventListener('mouseleave',()=>{closeEl.style.background='none'
-closeEl.style.color='rgba(245, 245, 247, 0.6)'})
-notification.style.transform='translateX(100%)'
-notification.style.transition='all 0.3s ease-out'
-setTimeout(()=>{notification.style.transform='translateX(0)'},10)
-setTimeout(()=>{if(notification.parentNode){closeEl.click()}},options.timeout||5000)
-return notification}
-recordFallbackEvent(type,data){const event={type,data,timestamp:Date.now(),userAgent:navigator.userAgent,url:window.location.href}
-try{const storageKey='ai-intervention-fallback-events'
-const events=JSON.parse(localStorage.getItem(storageKey)||'[]')
-const sevenDaysAgo=Date.now()-7*24*60*60*1000
-const validEvents=events.filter(e=>e.timestamp>sevenDaysAgo)
-validEvents.push(event)
-if(validEvents.length>50){validEvents.splice(0,validEvents.length-50)}
-localStorage.setItem(storageKey,JSON.stringify(validEvents))
-this.monitorLocalStorageUsage(storageKey)}catch(error){console.warn('无法记录降级事件:',error)
-this.cleanupLocalStorage()}
-if(this.config.debug){console.log('降级事件记录:',event)}}
-monitorLocalStorageUsage(key){try{const data=localStorage.getItem(key)
-if(data){const sizeInBytes=new Blob([data]).size
-const sizeInKB=(sizeInBytes/1024).toFixed(2)
-if(sizeInBytes>100*1024){console.warn(`localStorage事件记录过大: ${sizeInKB}KB，建议清理`)}
-if(this.config.debug){console.log(`localStorage事件记录大小: ${sizeInKB}KB`)}}}catch(error){console.warn('无法监控localStorage使用情况:',error)}}
-cleanupLocalStorage(){try{const storageKey='ai-intervention-fallback-events'
-const events=JSON.parse(localStorage.getItem(storageKey)||'[]')
-const oneDayAgo=Date.now()-24*60*60*1000
-const recentEvents=events.filter(e=>e.timestamp>oneDayAgo)
-if(recentEvents.length>20){recentEvents.splice(0,recentEvents.length-20)}
-localStorage.setItem(storageKey,JSON.stringify(recentEvents))
-console.log(`localStorage清理完成，保留 ${recentEvents.length} 个事件`)}catch(error){console.error('localStorage清理失败:',error)
-try{localStorage.removeItem('ai-intervention-fallback-events')
-console.log('已清空localStorage事件记录')}catch(clearError){console.error('无法清空localStorage:',clearError)}}}}
-const notificationManager=new NotificationManager()
-class SettingsManager{constructor(){this.storageKey='ai-intervention-agent-settings'
-this.defaultSettings={enabled:true,webEnabled:true,autoRequestPermission:true,soundEnabled:true,soundMute:false,soundVolume:80,mobileOptimized:true,mobileVibrate:true,barkEnabled:false,barkUrl:'https://api.day.app/push',barkDeviceKey:'',barkIcon:'',barkAction:'none'}
-this.initialized=false}
-async init(){if(this.initialized)return
-this.settings=await this.loadSettings()
-this.initEventListeners()
-this.initialized=true
-console.log('SettingsManager 初始化完成')}
-async loadSettings(){try{const response=await fetch('/api/get-notification-config')
-if(response.ok){const result=await response.json()
-if(result.status==='success'){const serverConfig=result.config
-const settings={enabled:serverConfig.enabled??this.defaultSettings.enabled,webEnabled:serverConfig.web_enabled??this.defaultSettings.webEnabled,autoRequestPermission:serverConfig.auto_request_permission??this.defaultSettings.autoRequestPermission,soundEnabled:serverConfig.sound_enabled??this.defaultSettings.soundEnabled,soundMute:serverConfig.sound_mute??this.defaultSettings.soundMute,soundVolume:serverConfig.sound_volume??this.defaultSettings.soundVolume,mobileOptimized:serverConfig.mobile_optimized??this.defaultSettings.mobileOptimized,mobileVibrate:serverConfig.mobile_vibrate??this.defaultSettings.mobileVibrate,barkEnabled:serverConfig.bark_enabled??this.defaultSettings.barkEnabled,barkUrl:serverConfig.bark_url??this.defaultSettings.barkUrl,barkDeviceKey:serverConfig.bark_device_key??this.defaultSettings.barkDeviceKey,barkIcon:serverConfig.bark_icon??this.defaultSettings.barkIcon,barkAction:serverConfig.bark_action??this.defaultSettings.barkAction}
-console.log('从服务器加载配置成功')
-return settings}}}catch(error){console.warn('从服务器加载配置失败，尝试localStorage:',error)}
-try{const stored=localStorage.getItem(this.storageKey)
-if(stored){const parsed=JSON.parse(stored)
-return{...this.defaultSettings,...parsed}}}catch(error){console.warn('加载设置失败，使用默认设置:',error)}
-return{...this.defaultSettings}}
-saveSettings(){try{localStorage.setItem(this.storageKey,JSON.stringify(this.settings))
-console.log('设置已保存')}catch(error){console.error('保存设置失败:',error)}}
-updateSetting(key,value){this.settings[key]=value
-this.saveSettings()
-this.applySettings()
-console.log(`设置已更新: ${key} = ${value}`)}
-applySettings(){if(notificationManager){notificationManager.updateConfig({enabled:this.settings.enabled,webEnabled:this.settings.webEnabled,autoRequestPermission:this.settings.autoRequestPermission,soundEnabled:this.settings.soundEnabled,soundMute:this.settings.soundMute,soundVolume:this.settings.soundVolume/100,mobileOptimized:this.settings.mobileOptimized,mobileVibrate:this.settings.mobileVibrate,barkEnabled:this.settings.barkEnabled,barkUrl:this.settings.barkUrl,barkDeviceKey:this.settings.barkDeviceKey,barkIcon:this.settings.barkIcon,barkAction:this.settings.barkAction})}
-this.syncConfigToBackend()}
-async syncConfigToBackend(){try{const response=await fetch('/api/update-notification-config',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(this.settings)})
-const result=await response.json()
-if(response.ok&&result.status==='success'){console.log('后端通知配置已同步')}else{console.warn('同步后端配置失败:',result.message)}}catch(error){console.error('同步后端配置失败:',error)}}
-resetSettings(){this.settings={...this.defaultSettings}
-this.saveSettings()
-this.updateUI()
-this.applySettings()
-console.log('设置已重置为默认值')}
-updateUI(){document.getElementById('notification-enabled').checked=this.settings.enabled
-document.getElementById('web-notification-enabled').checked=this.settings.webEnabled
-document.getElementById('auto-request-permission').checked=this.settings.autoRequestPermission
-document.getElementById('sound-notification-enabled').checked=this.settings.soundEnabled
-document.getElementById('sound-mute').checked=this.settings.soundMute
-document.getElementById('sound-volume').value=this.settings.soundVolume
-document.querySelector('.volume-value').textContent=`${this.settings.soundVolume}%`
-document.getElementById('mobile-optimized').checked=this.settings.mobileOptimized
-document.getElementById('mobile-vibrate').checked=this.settings.mobileVibrate
-document.getElementById('bark-notification-enabled').checked=this.settings.barkEnabled
-document.getElementById('bark-url').value=this.settings.barkUrl
-document.getElementById('bark-device-key').value=this.settings.barkDeviceKey
-document.getElementById('bark-icon').value=this.settings.barkIcon
-document.getElementById('bark-action').value=this.settings.barkAction}
-getStatusIcon(type){const icons={success:`<svg class="status-icon status-icon-success" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 16px; height: 16px; vertical-align: middle; margin-right: 4px; color: #4CAF50;"><polyline points="20 6 9 17 4 12"></polyline></svg>`,error:`<svg class="status-icon status-icon-error" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 16px; height: 16px; vertical-align: middle; margin-right: 4px; color: #F44336;"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`,warning:`<svg class="status-icon status-icon-warning" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 16px; height: 16px; vertical-align: middle; margin-right: 4px; color: #FF9800;"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>`,paused:`<svg class="status-icon status-icon-paused" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 16px; height: 16px; vertical-align: middle; margin-right: 4px; color: #9E9E9E;"><rect x="6" y="4" width="4" height="16"></rect><rect x="14" y="4" width="4" height="16"></rect></svg>`}
-return icons[type]||icons.warning}
-updateStatus(){const browserSupportHtml=notificationManager.isSupported?this.getStatusIcon('success')+'支持':this.getStatusIcon('error')+'不支持'
-let permissionHtml
-if(notificationManager.permission==='granted'){permissionHtml=this.getStatusIcon('success')+'已授权'}else if(notificationManager.permission==='denied'){permissionHtml=this.getStatusIcon('error')+'已拒绝'}else{permissionHtml=this.getStatusIcon('warning')+'未请求'}
-let audioStateHtml=this.getStatusIcon('error')+'不可用'
-if(notificationManager.audioContext){const state=notificationManager.audioContext.state
-switch(state){case'running':audioStateHtml=this.getStatusIcon('success')+'运行中'
-break
-case'suspended':audioStateHtml=this.getStatusIcon('paused')+'已暂停'
-break
-case'closed':audioStateHtml=this.getStatusIcon('error')+'已关闭'
-break
-default:audioStateHtml=this.getStatusIcon('warning')+state}}
-document.getElementById('browser-support-status').innerHTML=browserSupportHtml
-document.getElementById('notification-permission-status').innerHTML=permissionHtml
-document.getElementById('audio-status').innerHTML=audioStateHtml}
-initEventListeners(){const settingsBtn=document.getElementById('settings-btn')
-const settingsCloseBtn=document.getElementById('settings-close-btn')
-const testNotificationBtn=document.getElementById('test-notification-btn')
-const testBarkNotificationBtn=document.getElementById('test-bark-notification-btn')
-const resetSettingsBtn=document.getElementById('reset-settings-btn')
-if(settingsBtn){settingsBtn.addEventListener('click',e=>{e.stopPropagation()
-this.showSettings()})}
-if(settingsCloseBtn){settingsCloseBtn.addEventListener('click',()=>this.hideSettings())}
-if(testNotificationBtn){testNotificationBtn.addEventListener('click',()=>this.testNotification())}
-if(testBarkNotificationBtn){testBarkNotificationBtn.addEventListener('click',()=>this.testBarkNotification())}
-if(resetSettingsBtn){resetSettingsBtn.addEventListener('click',()=>this.resetSettings())}
-document.addEventListener('click',e=>{if(e.target.id==='settings-panel'){this.hideSettings()}})
-document.addEventListener('change',e=>{const settingMap={'notification-enabled':'enabled','web-notification-enabled':'webEnabled','auto-request-permission':'autoRequestPermission','sound-notification-enabled':'soundEnabled','sound-mute':'soundMute','mobile-optimized':'mobileOptimized','mobile-vibrate':'mobileVibrate','bark-notification-enabled':'barkEnabled'}
-if(settingMap[e.target.id]){this.updateSetting(settingMap[e.target.id],e.target.checked)}else if(e.target.id==='sound-volume'){this.updateSetting('soundVolume',parseInt(e.target.value))
-document.querySelector('.volume-value').textContent=`${e.target.value}%`}else if(e.target.id==='bark-url'){this.updateSetting('barkUrl',e.target.value)}else if(e.target.id==='bark-device-key'){this.updateSetting('barkDeviceKey',e.target.value)}else if(e.target.id==='bark-icon'){this.updateSetting('barkIcon',e.target.value)}else if(e.target.id==='bark-action'){this.updateSetting('barkAction',e.target.value)}})}
-async showSettings(){if(!this.initialized){try{await this.init()}catch(e){console.warn('SettingsManager 初始化失败（打开设置面板时）:',e)}}
-const panel=document.getElementById('settings-panel')
-if(panel){const container=document.querySelector('.container')
-if(container){container.style.overflow='visible'}
-panel.classList.remove('hidden')
-panel.style.display='flex'
-this.applySettingsTheme()}
-try{this.settings=await this.loadSettings()}catch(e){console.warn('打开设置面板时刷新配置失败，继续使用当前设置:',e)}
-this.updateUI()
-this.updateStatus()}
-applySettingsTheme(){const theme=document.documentElement.getAttribute('data-theme')
-if(!document.getElementById('settings-light-theme-styles')){const style=document.createElement('style')
-style.id='settings-light-theme-styles'
-style.textContent=`
+
+    // 添加到页面
+    document.body.appendChild(notification)
+
+    // 关闭按钮事件
+    closeEl.addEventListener('click', () => {
+      notification.style.transform = 'translateX(100%)'
+      notification.style.opacity = '0'
+      setTimeout(() => {
+        if (notification.parentNode) {
+          notification.parentNode.removeChild(notification)
+        }
+      }, 300)
+    })
+
+    closeEl.addEventListener('mouseenter', () => {
+      closeEl.style.background = 'rgba(255, 255, 255, 0.1)'
+      closeEl.style.color = '#f5f5f7'
+    })
+
+    closeEl.addEventListener('mouseleave', () => {
+      closeEl.style.background = 'none'
+      closeEl.style.color = 'rgba(245, 245, 247, 0.6)'
+    })
+
+    // 入场动画
+    notification.style.transform = 'translateX(100%)'
+    notification.style.transition = 'all 0.3s ease-out'
+    setTimeout(() => {
+      notification.style.transform = 'translateX(0)'
+    }, 10)
+
+    // 自动关闭
+    setTimeout(() => {
+      if (notification.parentNode) {
+        closeEl.click()
+      }
+    }, options.timeout || 5000)
+
+    return notification
+  }
+
+  recordFallbackEvent(type, data) {
+    // 记录降级事件用于分析和改进
+    const event = {
+      type,
+      data,
+      timestamp: Date.now(),
+      userAgent: navigator.userAgent,
+      url: window.location.href
+    }
+
+    // 性能优化：存储到本地存储
+    try {
+      const storageKey = 'ai-intervention-fallback-events'
+      const events = JSON.parse(localStorage.getItem(storageKey) || '[]')
+
+      // 性能优化：清理过期事件
+      const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000
+      const validEvents = events.filter(e => e.timestamp > sevenDaysAgo)
+
+      validEvents.push(event)
+
+      // 性能优化：只保留最近50个事件
+      if (validEvents.length > 50) {
+        validEvents.splice(0, validEvents.length - 50)
+      }
+
+      localStorage.setItem(storageKey, JSON.stringify(validEvents))
+
+      // 性能优化：监控存储空间使用
+      this.monitorLocalStorageUsage(storageKey)
+    } catch (error) {
+      console.warn('无法记录降级事件:', error)
+      // 如果存储失败，尝试清理存储空间
+      this.cleanupLocalStorage()
+    }
+
+    if (this.config.debug) {
+      console.log('降级事件记录:', event)
+    }
+  }
+
+  // 性能优化：监控 localStorage 使用情况
+  monitorLocalStorageUsage(key) {
+    try {
+      const data = localStorage.getItem(key)
+      if (data) {
+        const sizeInBytes = new Blob([data]).size
+        const sizeInKB = (sizeInBytes / 1024).toFixed(2)
+
+        if (sizeInBytes > 100 * 1024) {
+          // 超过100KB时警告
+          console.warn(`localStorage事件记录过大: ${sizeInKB}KB，建议清理`)
+        }
+
+        if (this.config.debug) {
+          console.log(`localStorage事件记录大小: ${sizeInKB}KB`)
+        }
+      }
+    } catch (error) {
+      console.warn('无法监控localStorage使用情况:', error)
+    }
+  }
+
+  // 性能优化：清理 localStorage
+  cleanupLocalStorage() {
+    try {
+      const storageKey = 'ai-intervention-fallback-events'
+      const events = JSON.parse(localStorage.getItem(storageKey) || '[]')
+
+      // 只保留最近24小时的事件
+      const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000
+      const recentEvents = events.filter(e => e.timestamp > oneDayAgo)
+
+      // 进一步限制到最多20个事件
+      if (recentEvents.length > 20) {
+        recentEvents.splice(0, recentEvents.length - 20)
+      }
+
+      localStorage.setItem(storageKey, JSON.stringify(recentEvents))
+      console.log(`localStorage清理完成，保留 ${recentEvents.length} 个事件`)
+    } catch (error) {
+      console.error('localStorage清理失败:', error)
+      // 最后手段：清空事件记录
+      try {
+        localStorage.removeItem('ai-intervention-fallback-events')
+        console.log('已清空localStorage事件记录')
+      } catch (clearError) {
+        console.error('无法清空localStorage:', clearError)
+      }
+    }
+  }
+}
+
+// 创建全局通知管理器实例
+const notificationManager = new NotificationManager()
+
+// 设置管理器
+class SettingsManager {
+  constructor() {
+    this.storageKey = 'ai-intervention-agent-settings'
+    this.defaultSettings = {
+      enabled: true,
+      webEnabled: true,
+      autoRequestPermission: true,
+      soundEnabled: true,
+      soundMute: false,
+      soundVolume: 80,
+      mobileOptimized: true,
+      mobileVibrate: true,
+      barkEnabled: false,
+      barkUrl: 'https://api.day.app/push',
+      barkDeviceKey: '',
+      barkIcon: '',
+      barkAction: 'none'
+    }
+    this.initialized = false
+    // 注意：不在构造函数中调用 init()，由 DOMContentLoaded 触发
+  }
+
+  async init() {
+    if (this.initialized) return
+    this.settings = await this.loadSettings()
+    this.initEventListeners()
+    this.initialized = true
+    console.log('SettingsManager 初始化完成')
+  }
+
+  async loadSettings() {
+    try {
+      // 优先从服务器加载配置
+      const response = await fetch('/api/get-notification-config')
+      if (response.ok) {
+        const result = await response.json()
+        if (result.status === 'success') {
+          // 将服务器配置映射到前端格式
+          const serverConfig = result.config
+          const settings = {
+            enabled: serverConfig.enabled ?? this.defaultSettings.enabled,
+            webEnabled: serverConfig.web_enabled ?? this.defaultSettings.webEnabled,
+            autoRequestPermission:
+              serverConfig.auto_request_permission ?? this.defaultSettings.autoRequestPermission,
+            soundEnabled: serverConfig.sound_enabled ?? this.defaultSettings.soundEnabled,
+            soundMute: serverConfig.sound_mute ?? this.defaultSettings.soundMute,
+            soundVolume: serverConfig.sound_volume ?? this.defaultSettings.soundVolume,
+            mobileOptimized: serverConfig.mobile_optimized ?? this.defaultSettings.mobileOptimized,
+            mobileVibrate: serverConfig.mobile_vibrate ?? this.defaultSettings.mobileVibrate,
+            barkEnabled: serverConfig.bark_enabled ?? this.defaultSettings.barkEnabled,
+            barkUrl: serverConfig.bark_url ?? this.defaultSettings.barkUrl,
+            barkDeviceKey: serverConfig.bark_device_key ?? this.defaultSettings.barkDeviceKey,
+            barkIcon: serverConfig.bark_icon ?? this.defaultSettings.barkIcon,
+            barkAction: serverConfig.bark_action ?? this.defaultSettings.barkAction
+          }
+          console.log('从服务器加载配置成功')
+          return settings
+        }
+      }
+    } catch (error) {
+      console.warn('从服务器加载配置失败，尝试localStorage:', error)
+    }
+
+    // 回退到localStorage
+    try {
+      const stored = localStorage.getItem(this.storageKey)
+      if (stored) {
+        const parsed = JSON.parse(stored)
+        return { ...this.defaultSettings, ...parsed }
+      }
+    } catch (error) {
+      console.warn('加载设置失败，使用默认设置:', error)
+    }
+    return { ...this.defaultSettings }
+  }
+
+  saveSettings() {
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(this.settings))
+      console.log('设置已保存')
+    } catch (error) {
+      console.error('保存设置失败:', error)
+    }
+  }
+
+  updateSetting(key, value) {
+    this.settings[key] = value
+    this.saveSettings()
+    this.applySettings()
+    console.log(`设置已更新: ${key} = ${value}`)
+  }
+
+  applySettings(options = {}) {
+    const { syncBackend = true } = options
+    // 更新前端通知管理器配置
+    if (notificationManager) {
+      notificationManager.updateConfig({
+        enabled: this.settings.enabled,
+        webEnabled: this.settings.webEnabled,
+        autoRequestPermission: this.settings.autoRequestPermission,
+        soundEnabled: this.settings.soundEnabled,
+        soundMute: this.settings.soundMute,
+        soundVolume: this.settings.soundVolume / 100,
+        mobileOptimized: this.settings.mobileOptimized,
+        mobileVibrate: this.settings.mobileVibrate,
+        barkEnabled: this.settings.barkEnabled,
+        barkUrl: this.settings.barkUrl,
+        barkDeviceKey: this.settings.barkDeviceKey,
+        barkIcon: this.settings.barkIcon,
+        barkAction: this.settings.barkAction
+      })
+    }
+
+    // 同步配置到后端
+    if (syncBackend) {
+      this.syncConfigToBackend()
+    }
+  }
+
+  async syncConfigToBackend() {
+    try {
+      const response = await fetch('/api/update-notification-config', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(this.settings)
+      })
+
+      const result = await response.json()
+      if (response.ok && result.status === 'success') {
+        console.log('后端通知配置已同步')
+      } else {
+        console.warn('同步后端配置失败:', result.message)
+      }
+    } catch (error) {
+      console.error('同步后端配置失败:', error)
+    }
+  }
+
+  resetSettings() {
+    this.settings = { ...this.defaultSettings }
+    this.saveSettings()
+    this.updateUI()
+    this.applySettings()
+    console.log('设置已重置为默认值')
+  }
+
+  updateUI() {
+    // 更新设置面板中的控件状态
+    document.getElementById('notification-enabled').checked = this.settings.enabled
+    document.getElementById('web-notification-enabled').checked = this.settings.webEnabled
+    document.getElementById('auto-request-permission').checked = this.settings.autoRequestPermission
+    document.getElementById('sound-notification-enabled').checked = this.settings.soundEnabled
+    document.getElementById('sound-mute').checked = this.settings.soundMute
+    document.getElementById('sound-volume').value = this.settings.soundVolume
+    document.querySelector('.volume-value').textContent = `${this.settings.soundVolume}%`
+    document.getElementById('mobile-optimized').checked = this.settings.mobileOptimized
+    document.getElementById('mobile-vibrate').checked = this.settings.mobileVibrate
+
+    // 更新 Bark 设置
+    document.getElementById('bark-notification-enabled').checked = this.settings.barkEnabled
+    document.getElementById('bark-url').value = this.settings.barkUrl
+    document.getElementById('bark-device-key').value = this.settings.barkDeviceKey
+    document.getElementById('bark-icon').value = this.settings.barkIcon
+    document.getElementById('bark-action').value = this.settings.barkAction
+  }
+
+  /**
+   * 获取状态图标 SVG（Claude 风格线条图标）
+   *
+   * 功能说明：
+   *   生成用于设置面板状态显示的 SVG 图标，替代原有的 emoji。
+   *   采用 Claude 官方设计风格：线条图标、适当的 stroke-width。
+   *
+   * 设计规范：
+   *   - 尺寸：16x16px
+   *   - stroke-width: 2（与其他图标一致）
+   *   - stroke-linecap/linejoin: round（圆润的线条端点）
+   *   - 垂直居中：vertical-align: middle
+   *   - 与文字间距：margin-right: 4px
+   *
+   * 颜色方案：
+   *   - success: #4CAF50（绿色）- 表示正常/已启用
+   *   - error: #F44336（红色）- 表示错误/已禁用
+   *   - warning: #FF9800（橙色）- 表示警告/未配置
+   *   - paused: #9E9E9E（灰色）- 表示暂停状态
+   *
+   * @param {string} type - 图标类型：'success' | 'error' | 'warning' | 'paused'
+   * @returns {string} SVG HTML 字符串，可直接插入到 innerHTML
+   */
+  getStatusIcon(type) {
+    const icons = {
+      // 成功图标（勾号）- 浏览器支持/通知已授权/音频运行中
+      success: `<svg class="status-icon status-icon-success" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 16px; height: 16px; vertical-align: middle; margin-right: 4px; color: #4CAF50;"><polyline points="20 6 9 17 4 12"></polyline></svg>`,
+      // 错误图标（叉号）- 不支持/已拒绝/已关闭
+      error: `<svg class="status-icon status-icon-error" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 16px; height: 16px; vertical-align: middle; margin-right: 4px; color: #F44336;"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`,
+      // 警告图标（感叹号三角形）- 未请求权限/未知状态
+      warning: `<svg class="status-icon status-icon-warning" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 16px; height: 16px; vertical-align: middle; margin-right: 4px; color: #FF9800;"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>`,
+      // 暂停图标（双竖线）- 音频已暂停
+      paused: `<svg class="status-icon status-icon-paused" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width: 16px; height: 16px; vertical-align: middle; margin-right: 4px; color: #9E9E9E;"><rect x="6" y="4" width="4" height="16"></rect><rect x="14" y="4" width="4" height="16"></rect></svg>`
+    }
+    // 默认返回警告图标，处理未知类型
+    return icons[type] || icons.warning
+  }
+
+  updateStatus() {
+    // 更新状态信息（使用 SVG 图标替代 emoji）
+    const browserSupportHtml = notificationManager.isSupported
+      ? this.getStatusIcon('success') + '支持'
+      : this.getStatusIcon('error') + '不支持'
+
+    let permissionHtml
+    if (notificationManager.permission === 'granted') {
+      permissionHtml = this.getStatusIcon('success') + '已授权'
+    } else if (notificationManager.permission === 'denied') {
+      permissionHtml = this.getStatusIcon('error') + '已拒绝'
+    } else {
+      permissionHtml = this.getStatusIcon('warning') + '未请求'
+    }
+
+    // 音频状态中文化
+    let audioStateHtml = this.getStatusIcon('error') + '不可用'
+    if (notificationManager.audioContext) {
+      const state = notificationManager.audioContext.state
+      switch (state) {
+        case 'running':
+          audioStateHtml = this.getStatusIcon('success') + '运行中'
+          break
+        case 'suspended':
+          audioStateHtml = this.getStatusIcon('paused') + '已暂停'
+          break
+        case 'closed':
+          audioStateHtml = this.getStatusIcon('error') + '已关闭'
+          break
+        default:
+          audioStateHtml = this.getStatusIcon('warning') + state
+      }
+    }
+
+    document.getElementById('browser-support-status').innerHTML = browserSupportHtml
+    document.getElementById('notification-permission-status').innerHTML = permissionHtml
+    document.getElementById('audio-status').innerHTML = audioStateHtml
+  }
+
+  initEventListeners() {
+    // 设置按钮点击事件 - 使用直接绑定确保可靠
+    const settingsBtn = document.getElementById('settings-btn')
+    const settingsCloseBtn = document.getElementById('settings-close-btn')
+    const testNotificationBtn = document.getElementById('test-notification-btn')
+    const testBarkNotificationBtn = document.getElementById('test-bark-notification-btn')
+    const resetSettingsBtn = document.getElementById('reset-settings-btn')
+
+    if (settingsBtn) {
+      settingsBtn.addEventListener('click', e => {
+        e.stopPropagation()
+        this.showSettings()
+      })
+    }
+    if (settingsCloseBtn) {
+      settingsCloseBtn.addEventListener('click', () => this.hideSettings())
+    }
+    if (testNotificationBtn) {
+      testNotificationBtn.addEventListener('click', () => this.testNotification())
+    }
+    if (testBarkNotificationBtn) {
+      testBarkNotificationBtn.addEventListener('click', () => this.testBarkNotification())
+    }
+    if (resetSettingsBtn) {
+      resetSettingsBtn.addEventListener('click', () => this.resetSettings())
+    }
+
+    // 主题切换按钮点击事件 - 已由 theme.js 处理，此处删除避免重复绑定
+
+    // 设置面板背景点击关闭
+    document.addEventListener('click', e => {
+      if (e.target.id === 'settings-panel') {
+        this.hideSettings()
+      }
+    })
+
+    // 设置项变更事件
+    document.addEventListener('change', e => {
+      const settingMap = {
+        'notification-enabled': 'enabled',
+        'web-notification-enabled': 'webEnabled',
+        'auto-request-permission': 'autoRequestPermission',
+        'sound-notification-enabled': 'soundEnabled',
+        'sound-mute': 'soundMute',
+        'mobile-optimized': 'mobileOptimized',
+        'mobile-vibrate': 'mobileVibrate',
+        'bark-notification-enabled': 'barkEnabled'
+      }
+
+      if (settingMap[e.target.id]) {
+        this.updateSetting(settingMap[e.target.id], e.target.checked)
+      } else if (e.target.id === 'sound-volume') {
+        this.updateSetting('soundVolume', parseInt(e.target.value))
+        document.querySelector('.volume-value').textContent = `${e.target.value}%`
+      } else if (e.target.id === 'bark-url') {
+        this.updateSetting('barkUrl', e.target.value)
+      } else if (e.target.id === 'bark-device-key') {
+        this.updateSetting('barkDeviceKey', e.target.value)
+      } else if (e.target.id === 'bark-icon') {
+        this.updateSetting('barkIcon', e.target.value)
+      } else if (e.target.id === 'bark-action') {
+        this.updateSetting('barkAction', e.target.value)
+      }
+    })
+  }
+
+  async showSettings() {
+    // 防御性：确保已初始化（极端情况下用户可能在 init() 未完成时快速点击）
+    if (!this.initialized) {
+      try {
+        await this.init()
+      } catch (e) {
+        console.warn('SettingsManager 初始化失败（打开设置面板时）:', e)
+      }
+    }
+
+    const panel = document.getElementById('settings-panel')
+    if (panel) {
+      // 临时移除 container 的 overflow: hidden，以便设置面板可以覆盖整个屏幕
+      const container = document.querySelector('.container')
+      if (container) {
+        container.style.overflow = 'visible'
+      }
+
+      panel.classList.remove('hidden') // 移除 hidden 类（它使用了 !important）
+      panel.style.display = 'flex'
+
+      // 浅色主题适配
+      this.applySettingsTheme()
+    }
+
+    // 每次打开设置面板都从后端刷新一次配置
+    // 目的：
+    // - 让“外部编辑 config.jsonc”能在不刷新页面的情况下反映到 UI
+    // - 避免打开面板时把旧的本地缓存配置反向写回后端（覆盖外部修改）
+    try {
+      this.settings = await this.loadSettings()
+    } catch (e) {
+      console.warn('打开设置面板时刷新配置失败，继续使用当前设置:', e)
+    }
+
+    this.updateUI()
+    this.updateStatus()
+  }
+
+  applySettingsTheme() {
+    const theme = document.documentElement.getAttribute('data-theme')
+
+    // 动态注入浅色主题样式（解决 CSS 优先级问题）
+    if (!document.getElementById('settings-light-theme-styles')) {
+      const style = document.createElement('style')
+      style.id = 'settings-light-theme-styles'
+      style.textContent = `
         [data-theme="light"] .settings-panel {
           background: rgba(0, 0, 0, 0.7) !important;
         }
@@ -666,449 +2172,1411 @@ style.textContent=`
           color: #141413 !important;
         }
       `
-document.head.appendChild(style)}}
-hideSettings(){const panel=document.getElementById('settings-panel')
-if(panel){const container=document.querySelector('.container')
-if(container){container.style.overflow=''}
-panel.classList.add('hidden')
-panel.style.display='none'}}
-async testNotification(){try{await notificationManager.sendNotification('设置测试','这是一个测试通知，用于验证当前设置是否正常工作',{tag:'settings-test',requireInteraction:false})
-showStatus('测试通知已发送','success')}catch(error){console.error('测试通知失败:',error)
-showStatus('测试通知失败: '+error.message,'error')}}
-async testBarkNotification(){try{if(!this.settings.barkEnabled){showStatus('请先启用 Bark 通知','warning')
-return}
-if(!this.settings.barkUrl||!this.settings.barkDeviceKey){showStatus('请先配置 Bark URL 和 Device Key','warning')
-return}
-showStatus('正在发送 Bark 测试通知...','info')
-const response=await fetch('/api/test-bark',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({bark_url:this.settings.barkUrl,bark_device_key:this.settings.barkDeviceKey,bark_icon:this.settings.barkIcon,bark_action:this.settings.barkAction})})
-const result=await response.json()
-if(response.ok&&result.status==='success'){showStatus(result.message,'success')
-console.log('Bark 通知发送成功:',result)}else{showStatus(result.message||'Bark 通知发送失败','error')
-console.error('Bark 通知发送失败:',result)}}catch(error){console.error('Bark 测试通知失败:',error)
-showStatus('Bark 测试通知失败: '+error.message,'error')}}}
-const settingsManager=new SettingsManager()
-function debounce(func,wait){let timeout
-return function executedFunction(...args){const later=()=>{clearTimeout(timeout)
-func(...args)}
-clearTimeout(timeout)
-timeout=setTimeout(later,wait)}}
-function throttle(func,limit){let inThrottle
-return function(...args){if(!inThrottle){func.apply(this,args)
-inThrottle=true
-setTimeout(()=>(inThrottle=false),limit)}}}
-function rafUpdate(callback){if(window.requestAnimationFrame){requestAnimationFrame(callback)}else{setTimeout(callback,16)}}
-const SUPPORTED_IMAGE_TYPES=['image/jpeg','image/jpg','image/png','image/gif','image/webp','image/bmp','image/svg+xml']
-const MAX_IMAGE_SIZE=10*1024*1024
-const MAX_IMAGE_COUNT=10
-const MAX_IMAGE_DIMENSION=1920
-const COMPRESS_QUALITY=0.8
-function validateImageFile(file){if(typeof ValidationUtils!=='undefined'){const result=ValidationUtils.validateImageFile(file)
-return result.errors}
-const errors=[]
-if(!file||!file.type){errors.push('无效的文件对象')
-return errors}
-if(!SUPPORTED_IMAGE_TYPES.includes(file.type)){errors.push(`不支持的文件格式: ${file.type}`)}
-if(file.size>MAX_IMAGE_SIZE){errors.push(`文件大小超过限制: ${(file.size / 1024 / 1024).toFixed(2)}MB > 10MB`)}
-if(file.name&&file.name.length>255){errors.push('文件名过长')}
-return errors}
-function sanitizeFileName(fileName){if(typeof ValidationUtils!=='undefined'){return ValidationUtils.sanitizeFilename(fileName,100)}
-return fileName.replace(/[<>:"/\\|?*]/g,'').replace(/\s+/g,'_').trim().substring(0,100)}
-let objectURLs=new Set()
-let urlToFileMap=new WeakMap()
-let urlCreationTime=new Map()
-function createObjectURL(file){try{const url=URL.createObjectURL(file)
-objectURLs.add(url)
-urlToFileMap.set(file,url)
-urlCreationTime.set(url,Date.now())
-setTimeout(()=>{if(objectURLs.has(url)){console.warn(`自动清理过期的URL对象: ${url}`)
-revokeObjectURL(url)}},30*60*1000)
-return url}catch(error){console.error('创建Object URL失败:',error)
-return null}}
-function revokeObjectURL(url){if(!url)return
-try{if(objectURLs.has(url)){URL.revokeObjectURL(url)
-objectURLs.delete(url)
-urlCreationTime.delete(url)
-console.debug(`已清理URL对象: ${url}`)}}catch(error){console.error('清理URL对象失败:',error)}}
-function cleanupAllObjectURLs(){console.log(`开始清理 ${objectURLs.size} 个URL对象`)
-const startTime=performance.now()
-objectURLs.forEach(url=>{try{URL.revokeObjectURL(url)}catch(error){console.error(`清理URL失败: ${url}`,error)}})
-objectURLs.clear()
-urlCreationTime.clear()
-const endTime=performance.now()
-console.log(`URL对象清理完成，耗时: ${(endTime - startTime).toFixed(2)}ms`)}
-function startPeriodicCleanup(){setInterval(()=>{const now=Date.now()
-const expiredUrls=[]
-urlCreationTime.forEach((creationTime,url)=>{if(now-creationTime>20*60*1000){expiredUrls.push(url)}})
-if(expiredUrls.length>0){console.log(`定期清理 ${expiredUrls.length} 个过期URL对象`)
-expiredUrls.forEach(url=>revokeObjectURL(url))}},5*60*1000)}
-function compressImage(file){return new Promise(resolve=>{if(file.type==='image/svg+xml'||file.type==='image/gif'){resolve(file)
-return}
-const MAX_RETURN_BYTES=2*1024*1024
-const forceCompress=file.size>MAX_RETURN_BYTES
-const isLargeFile=file.size>5*1024*1024
-const canvas=document.createElement('canvas')
-const ctx=canvas.getContext('2d',{alpha:file.type==='image/png',willReadFrequently:false})
-if(!ctx){resolve(file)
-return}
-const img=new Image()
-const objectURL=createObjectURL(file)
-img.onload=()=>{let{width,height}=img
-const originalArea=width*height
-let maxDimension=MAX_IMAGE_DIMENSION
-if(forceCompress||isLargeFile||originalArea>4000000){maxDimension=Math.min(MAX_IMAGE_DIMENSION,1200)}
-if(width>maxDimension||height>maxDimension){const ratio=Math.min(maxDimension/width,maxDimension/height)
-width=Math.floor(width*ratio)
-height=Math.floor(height*ratio)}
-let currentWidth=width
-let currentHeight=height
-canvas.width=currentWidth
-canvas.height=currentHeight
-ctx.imageSmoothingEnabled=true
-ctx.imageSmoothingQuality='high'
-let quality=COMPRESS_QUALITY
-if(isLargeFile){quality=Math.max(0.6,COMPRESS_QUALITY-0.2)}
-if(forceCompress){quality=Math.min(quality,0.75)}
-const mimeCandidates=[]
-if(file.type==='image/png'){if(forceCompress||isLargeFile||originalArea>4000000){mimeCandidates.push('image/webp','image/jpeg')}else{mimeCandidates.push('image/png')}}else if(file.type==='image/webp'){mimeCandidates.push('image/webp','image/jpeg')}else{if(forceCompress){mimeCandidates.push('image/webp','image/jpeg')}else{mimeCandidates.push('image/jpeg')}}
-const getExtensionForMime=mimeType=>{if(mimeType==='image/png')return'.png'
-if(mimeType==='image/webp')return'.webp'
-if(mimeType==='image/jpeg')return'.jpg'
-return null}
-const replaceExtension=(filename,newExt)=>{if(!filename||!newExt)return filename
-const safeName=sanitizeFileName(filename)
-const withoutExt=safeName.replace(/\.[^/.]+$/,'')
-return`${withoutExt}${newExt}`}
-const logCompression=(blob,finalName)=>{try{const ratio=((1-blob.size/file.size)*100).toFixed(1)
-console.log(`图片压缩: ${file.name} ${(file.size / 1024).toFixed(2)}KB → ${(
+      document.head.appendChild(style)
+    }
+  }
+
+  hideSettings() {
+    const panel = document.getElementById('settings-panel')
+    if (panel) {
+      // 恢复 container 的 overflow
+      const container = document.querySelector('.container')
+      if (container) {
+        container.style.overflow = ''
+      }
+
+      panel.classList.add('hidden') // 添加 hidden 类
+      panel.style.display = 'none'
+    }
+  }
+
+  async testNotification() {
+    try {
+      await notificationManager.sendNotification(
+        '设置测试',
+        '这是一个测试通知，用于验证当前设置是否正常工作',
+        {
+          tag: 'settings-test',
+          requireInteraction: false
+        }
+      )
+      showStatus('测试通知已发送', 'success')
+    } catch (error) {
+      console.error('测试通知失败:', error)
+      showStatus('测试通知失败: ' + error.message, 'error')
+    }
+  }
+
+  async testBarkNotification() {
+    try {
+      if (!this.settings.barkEnabled) {
+        showStatus('请先启用 Bark 通知', 'warning')
+        return
+      }
+
+      if (!this.settings.barkUrl || !this.settings.barkDeviceKey) {
+        showStatus('请先配置 Bark URL 和 Device Key', 'warning')
+        return
+      }
+
+      // 显示发送中状态
+      showStatus('正在发送 Bark 测试通知...', 'info')
+
+      // 通过后端API发送Bark通知，避免CORS问题
+      const response = await fetch('/api/test-bark', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          bark_url: this.settings.barkUrl,
+          bark_device_key: this.settings.barkDeviceKey,
+          bark_icon: this.settings.barkIcon,
+          bark_action: this.settings.barkAction
+        })
+      })
+
+      const result = await response.json()
+
+      if (response.ok && result.status === 'success') {
+        showStatus(result.message, 'success')
+        console.log('Bark 通知发送成功:', result)
+      } else {
+        showStatus(result.message || 'Bark 通知发送失败', 'error')
+        console.error('Bark 通知发送失败:', result)
+      }
+    } catch (error) {
+      console.error('Bark 测试通知失败:', error)
+      showStatus('Bark 测试通知失败: ' + error.message, 'error')
+    }
+  }
+}
+
+// 创建全局设置管理器实例
+const settingsManager = new SettingsManager()
+
+// 性能优化工具函数
+
+// 防抖函数
+function debounce(func, wait) {
+  let timeout
+  return function executedFunction(...args) {
+    const later = () => {
+      clearTimeout(timeout)
+      func(...args)
+    }
+    clearTimeout(timeout)
+    timeout = setTimeout(later, wait)
+  }
+}
+
+// 节流函数
+function throttle(func, limit) {
+  let inThrottle
+  return function (...args) {
+    if (!inThrottle) {
+      func.apply(this, args)
+      inThrottle = true
+      setTimeout(() => (inThrottle = false), limit)
+    }
+  }
+}
+
+// RAF优化的更新函数
+function rafUpdate(callback) {
+  if (window.requestAnimationFrame) {
+    requestAnimationFrame(callback)
+  } else {
+    setTimeout(callback, 16) // 降级为60fps
+  }
+}
+
+// 支持的图片格式
+const SUPPORTED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/bmp',
+  'image/svg+xml'
+]
+const MAX_IMAGE_SIZE = 10 * 1024 * 1024 // 10MB
+const MAX_IMAGE_COUNT = 10
+const MAX_IMAGE_DIMENSION = 1920 // 最大宽度或高度
+const COMPRESS_QUALITY = 0.8 // 压缩质量 (0.1-1.0)
+
+/**
+ * 验证图片文件（使用 ValidationUtils 工具类）
+ * @param {File} file - 要验证的文件对象
+ * @returns {string[]} 错误信息数组
+ */
+function validateImageFile(file) {
+  // 使用 ValidationUtils 进行验证（如果可用）
+  if (typeof ValidationUtils !== 'undefined') {
+    const result = ValidationUtils.validateImageFile(file)
+    return result.errors
+  }
+
+  // 回退到基础验证
+  const errors = []
+  if (!file || !file.type) {
+    errors.push('无效的文件对象')
+    return errors
+  }
+  if (!SUPPORTED_IMAGE_TYPES.includes(file.type)) {
+    errors.push(`不支持的文件格式: ${file.type}`)
+  }
+  if (file.size > MAX_IMAGE_SIZE) {
+    errors.push(`文件大小超过限制: ${(file.size / 1024 / 1024).toFixed(2)}MB > 10MB`)
+  }
+  if (file.name && file.name.length > 255) {
+    errors.push('文件名过长')
+  }
+  return errors
+}
+
+/**
+ * 安全的文件名清理（使用 ValidationUtils 工具类）
+ * @param {string} fileName - 原始文件名
+ * @returns {string} 清理后的安全文件名
+ */
+function sanitizeFileName(fileName) {
+  // 使用 ValidationUtils 进行清理（如果可用）
+  if (typeof ValidationUtils !== 'undefined') {
+    return ValidationUtils.sanitizeFilename(fileName, 100)
+  }
+
+  // 回退到基础清理
+  return fileName
+    .replace(/[<>:"/\\|?*]/g, '')
+    .replace(/\s+/g, '_')
+    .trim()
+    .substring(0, 100)
+}
+
+// 注意：已移除 fileToBase64 函数，现在直接使用文件对象上传
+
+// 改进的内存管理跟踪：防止内存泄漏
+let objectURLs = new Set()
+let urlToFileMap = new WeakMap() // 使用WeakMap跟踪URL与文件的关联
+let urlCreationTime = new Map() // 跟踪URL创建时间，用于自动清理
+
+// 创建安全的Object URL
+function createObjectURL(file) {
+  try {
+    const url = URL.createObjectURL(file)
+    objectURLs.add(url)
+    urlToFileMap.set(file, url)
+    urlCreationTime.set(url, Date.now())
+
+    // 设置自动清理定时器（30分钟后自动清理）
+    setTimeout(() => {
+      if (objectURLs.has(url)) {
+        console.warn(`自动清理过期的URL对象: ${url}`)
+        revokeObjectURL(url)
+      }
+    }, 30 * 60 * 1000) // 30分钟
+
+    return url
+  } catch (error) {
+    console.error('创建Object URL失败:', error)
+    return null
+  }
+}
+
+// 清理Object URL
+function revokeObjectURL(url) {
+  if (!url) return
+
+  try {
+    if (objectURLs.has(url)) {
+      URL.revokeObjectURL(url)
+      objectURLs.delete(url)
+      urlCreationTime.delete(url)
+      console.debug(`已清理URL对象: ${url}`)
+    }
+  } catch (error) {
+    console.error('清理URL对象失败:', error)
+  }
+}
+
+// 清理所有Object URLs
+function cleanupAllObjectURLs() {
+  console.log(`开始清理 ${objectURLs.size} 个URL对象`)
+  const startTime = performance.now()
+
+  objectURLs.forEach(url => {
+    try {
+      URL.revokeObjectURL(url)
+    } catch (error) {
+      console.error(`清理URL失败: ${url}`, error)
+    }
+  })
+
+  objectURLs.clear()
+  urlCreationTime.clear()
+
+  const endTime = performance.now()
+  console.log(`URL对象清理完成，耗时: ${(endTime - startTime).toFixed(2)}ms`)
+}
+
+// 定期清理过期的URL对象（每5分钟检查一次）
+function startPeriodicCleanup() {
+  setInterval(() => {
+    const now = Date.now()
+    const expiredUrls = []
+
+    urlCreationTime.forEach((creationTime, url) => {
+      // 清理超过20分钟的URL对象
+      if (now - creationTime > 20 * 60 * 1000) {
+        expiredUrls.push(url)
+      }
+    })
+
+    if (expiredUrls.length > 0) {
+      console.log(`定期清理 ${expiredUrls.length} 个过期URL对象`)
+      expiredUrls.forEach(url => revokeObjectURL(url))
+    }
+  }, 5 * 60 * 1000) // 每5分钟检查一次
+}
+
+// 优化的图片压缩函数
+function compressImage(file) {
+  return new Promise(resolve => {
+    // SVG 图片和 GIF 不进行压缩
+    if (file.type === 'image/svg+xml' || file.type === 'image/gif') {
+      resolve(file)
+      return
+    }
+
+    // 强制压缩：避免大图直接原样返回到 MCP 调用方（base64 会非常大）
+    const MAX_RETURN_BYTES = 2 * 1024 * 1024 // 2MB
+    const forceCompress = file.size > MAX_RETURN_BYTES
+
+    // 大文件使用更激进的压缩
+    const isLargeFile = file.size > 5 * 1024 * 1024 // 5MB
+
+    const canvas = document.createElement('canvas')
+    const ctx = canvas.getContext('2d', {
+      alpha: file.type === 'image/png',
+      willReadFrequently: false
+    })
+    if (!ctx) {
+      resolve(file)
+      return
+    }
+    const img = new Image()
+
+    const objectURL = createObjectURL(file)
+
+    img.onload = () => {
+      // 计算压缩后的尺寸
+      let { width, height } = img
+      const originalArea = width * height
+
+      // 大图片使用更激进的压缩
+      let maxDimension = MAX_IMAGE_DIMENSION
+      if (forceCompress || isLargeFile || originalArea > 4000000) {
+        // 4MP
+        maxDimension = Math.min(MAX_IMAGE_DIMENSION, 1200)
+      }
+
+      if (width > maxDimension || height > maxDimension) {
+        const ratio = Math.min(maxDimension / width, maxDimension / height)
+        width = Math.floor(width * ratio)
+        height = Math.floor(height * ratio)
+      }
+
+      let currentWidth = width
+      let currentHeight = height
+
+      canvas.width = currentWidth
+      canvas.height = currentHeight
+
+      // 优化的绘制设置
+      ctx.imageSmoothingEnabled = true
+      ctx.imageSmoothingQuality = 'high'
+
+      // 根据文件大小调整初始压缩质量
+      let quality = COMPRESS_QUALITY
+      if (isLargeFile) {
+        quality = Math.max(0.6, COMPRESS_QUALITY - 0.2)
+      }
+      if (forceCompress) {
+        quality = Math.min(quality, 0.75)
+      }
+
+      // 选择输出格式：
+      // - PNG：小图尽量保持 PNG；大图强制转 WebP/JPEG（PNG 通常无法“有损压缩”）
+      // - 其他：优先 WebP（若浏览器不支持则回退 JPEG）
+      const mimeCandidates = []
+      if (file.type === 'image/png') {
+        if (forceCompress || isLargeFile || originalArea > 4000000) {
+          mimeCandidates.push('image/webp', 'image/jpeg')
+        } else {
+          mimeCandidates.push('image/png')
+        }
+      } else if (file.type === 'image/webp') {
+        mimeCandidates.push('image/webp', 'image/jpeg')
+      } else {
+        if (forceCompress) {
+          mimeCandidates.push('image/webp', 'image/jpeg')
+        } else {
+          mimeCandidates.push('image/jpeg')
+        }
+      }
+
+      const getExtensionForMime = mimeType => {
+        if (mimeType === 'image/png') return '.png'
+        if (mimeType === 'image/webp') return '.webp'
+        if (mimeType === 'image/jpeg') return '.jpg'
+        return null
+      }
+
+      const replaceExtension = (filename, newExt) => {
+        if (!filename || !newExt) return filename
+        const safeName = sanitizeFileName(filename)
+        const withoutExt = safeName.replace(/\.[^/.]+$/, '')
+        return `${withoutExt}${newExt}`
+      }
+
+      const logCompression = (blob, finalName) => {
+        try {
+          const ratio = ((1 - blob.size / file.size) * 100).toFixed(1)
+          console.log(
+            `图片压缩: ${file.name} ${(file.size / 1024).toFixed(2)}KB → ${(
               blob.size / 1024
-            ).toFixed(2)}KB (压缩率: ${ratio}%) 输出: ${finalName}`)}catch(_){}}
-let attempt=0
-const MAX_ATTEMPTS=8
-const tryToBlob=mimeIndex=>{const outType=mimeCandidates[mimeIndex]
-if(!outType){resolve(file)
-return}
-canvas.toBlob(blob=>{if(!blob)return tryToBlob(mimeIndex+1)
-if(!blob.type)return tryToBlob(mimeIndex+1)
-const finalMimeType=blob.type||outType
-const ext=getExtensionForMime(finalMimeType)
-const finalName=ext?replaceExtension(file.name,ext):file.name
-const compressedFile=new File([blob],finalName,{type:finalMimeType,lastModified:file.lastModified})
-if(!forceCompress){if(blob.size<file.size){logCompression(blob,finalName)
-resolve(compressedFile)}else{resolve(file)}
-return}
-if(blob.size<=MAX_RETURN_BYTES){logCompression(blob,finalName)
-resolve(compressedFile)
-return}
-attempt++
-if(attempt>=MAX_ATTEMPTS){console.warn(`图片压缩：已达到最大尝试次数，但仍超过 ${(MAX_RETURN_BYTES / 1024 / 1024).toFixed(
+            ).toFixed(2)}KB (压缩率: ${ratio}%) 输出: ${finalName}`
+          )
+        } catch (_) {
+          // ignore
+        }
+      }
+
+      let attempt = 0
+      const MAX_ATTEMPTS = 8
+
+      const tryToBlob = mimeIndex => {
+        const outType = mimeCandidates[mimeIndex]
+        if (!outType) {
+          resolve(file)
+          return
+        }
+
+        canvas.toBlob(
+          blob => {
+            if (!blob) return tryToBlob(mimeIndex + 1)
+
+            // 确保“声明的 MIME”与“真实文件内容”一致（避免后端 MIME 不一致拒绝）
+            if (!blob.type) return tryToBlob(mimeIndex + 1)
+
+            const finalMimeType = blob.type || outType
+            const ext = getExtensionForMime(finalMimeType)
+            const finalName = ext ? replaceExtension(file.name, ext) : file.name
+
+            const compressedFile = new File([blob], finalName, {
+              type: finalMimeType,
+              lastModified: file.lastModified
+            })
+
+            // 非强制：仅在变小时采用
+            if (!forceCompress) {
+              if (blob.size < file.size) {
+                logCompression(blob, finalName)
+                resolve(compressedFile)
+              } else {
+                resolve(file)
+              }
+              return
+            }
+
+            // 强制：先满足上限；否则继续降质/缩放
+            if (blob.size <= MAX_RETURN_BYTES) {
+              logCompression(blob, finalName)
+              resolve(compressedFile)
+              return
+            }
+
+            attempt++
+            if (attempt >= MAX_ATTEMPTS) {
+              console.warn(
+                `图片压缩：已达到最大尝试次数，但仍超过 ${(MAX_RETURN_BYTES / 1024 / 1024).toFixed(
                   1
-                )}MB，将返回当前压缩版本`)
-logCompression(blob,finalName)
-resolve(compressedFile)
-return}
-if(quality>0.55){quality=Math.max(0.55,quality-0.1)
-return tryToBlob(0)}
-const nextWidth=Math.max(320,Math.floor(currentWidth*0.85))
-const nextHeight=Math.max(320,Math.floor(currentHeight*0.85))
-if(nextWidth===currentWidth&&nextHeight===currentHeight){logCompression(blob,finalName)
-resolve(compressedFile)
-return}
-currentWidth=nextWidth
-currentHeight=nextHeight
-canvas.width=currentWidth
-canvas.height=currentHeight
-ctx.imageSmoothingEnabled=true
-ctx.imageSmoothingQuality='high'
-rafUpdate(()=>{ctx.drawImage(img,0,0,currentWidth,currentHeight)
-tryToBlob(0)})},outType,quality)}
-rafUpdate(()=>{ctx.drawImage(img,0,0,currentWidth,currentHeight)
-revokeObjectURL(objectURL)
-tryToBlob(0)})}
-img.onerror=()=>{revokeObjectURL(objectURL)
-resolve(file)}
-img.src=objectURL})}
-async function addImageToList(file){if(selectedImages.length>=MAX_IMAGE_COUNT){showStatus(`最多只能上传 ${MAX_IMAGE_COUNT} 张图片`,'error')
-return false}
-const errors=validateImageFile(file)
-if(errors.length>0){showStatus(errors.join('; '),'error')
-return false}
-const isDuplicate=selectedImages.some(img=>img.name===file.name&&img.size===file.size&&img.lastModified===file.lastModified)
-if(isDuplicate){showStatus('该图片已经添加过了','error')
-return false}
-const imageId=Date.now()+Math.random()
-try{const timestamp=Date.now()
-const imageItem={id:imageId,file:file,name:file.name,size:file.size,base64:null,timestamp:timestamp,lastModified:file.lastModified}
-selectedImages.push(imageItem)
-renderImagePreview(imageItem,true)
-updateImageCounter()
-const processedFile=await compressImage(file)
-imageItem.file=processedFile
-imageItem.size=processedFile.size
-const previewUrl=createObjectURL(processedFile)
-if(previewUrl){imageItem.previewUrl=previewUrl}else{throw new Error('创建预览URL失败')}
-renderImagePreview(imageItem,false)
-console.log('图片添加成功:',file.name,`(${(imageItem.size / 1024).toFixed(2)}KB)`)
-return true}catch(error){console.error('图片处理失败:',error)
-showStatus('图片处理失败: '+error.message,'error')
-try{const failed=selectedImages.find(img=>img.id===imageId)
-if(failed&&failed.previewUrl&&failed.previewUrl.startsWith('blob:')){revokeObjectURL(failed.previewUrl)}}catch(_){}
-selectedImages=selectedImages.filter(img=>img.id!==imageId)
-const previewElement=document.getElementById(`preview-${imageId}`)
-if(previewElement){previewElement.remove()}
-updateImageCounter()
-updateImagePreviewVisibility()
-return false}}
-let domUpdateQueue=[]
-let domUpdateScheduled=false
-function scheduleDOMUpdate(callback){domUpdateQueue.push(callback)
-if(!domUpdateScheduled){domUpdateScheduled=true
-rafUpdate(()=>{const fragment=document.createDocumentFragment()
-domUpdateQueue.forEach(callback=>callback(fragment))
-domUpdateQueue=[]
-domUpdateScheduled=false})}}
-function renderImagePreview(imageItem,isLoading=false){rafUpdate(()=>{const previewContainer=document.getElementById('image-previews')
-if(!previewContainer){console.error('图片预览容器 #image-previews 未找到，无法渲染预览')
-return}
-let previewElement=document.getElementById(`preview-${imageItem.id}`)
-if(!previewElement){previewElement=document.createElement('div')
-previewElement.id=`preview-${imageItem.id}`
-previewElement.className='image-preview-item'
-previewContainer.appendChild(previewElement)}
-const replacePreviewChildren=(container,built)=>{const fragment=document.createDocumentFragment()
-while(built.firstChild){fragment.appendChild(built.firstChild)}
-DOMSecurity.replaceContent(container,fragment)}
-const newPreviewElement=DOMSecurity.createImagePreview(imageItem,isLoading)
-replacePreviewChildren(previewElement,newPreviewElement)
-if(!isLoading&&imageItem.previewUrl){const img=new Image()
-img.onload=()=>{rafUpdate(()=>{const updatedPreviewElement=DOMSecurity.createImagePreview(imageItem,false)
-replacePreviewChildren(previewElement,updatedPreviewElement)})}
-img.src=imageItem.previewUrl}})}
-function sanitizeText(text){const div=document.createElement('div')
-div.textContent=text
-return div.innerHTML}
-function removeImage(imageId){const imageToRemove=selectedImages.find(img=>img.id==imageId)
-if(imageToRemove&&imageToRemove.previewUrl&&imageToRemove.previewUrl.startsWith('blob:')){revokeObjectURL(imageToRemove.previewUrl)}
-selectedImages=selectedImages.filter(img=>img.id!=imageId)
-const previewElement=document.getElementById(`preview-${imageId}`)
-if(previewElement){previewElement.remove()}
-updateImageCounter()
-updateImagePreviewVisibility()}
-function clearAllImages(){selectedImages.forEach(img=>{if(img.previewUrl&&img.previewUrl.startsWith('blob:')){revokeObjectURL(img.previewUrl)}})
-selectedImages=[]
-const previewContainer=document.getElementById('image-previews')
-DOMSecurity.clearContent(previewContainer)
-updateImageCounter()
-updateImagePreviewVisibility()
-if(window.gc&&typeof window.gc==='function'){setTimeout(()=>window.gc(),1000)}
-console.log('所有图片已清除，内存已释放')}
-function cleanupOnUnload(){try{if(hourglassAnimation){hourglassAnimation.destroy()
-hourglassAnimation=null}}catch(e){}
-try{const container=document.getElementById('hourglass-lottie')
-if(container)container.textContent=''}catch(e){}
-cleanupAllObjectURLs()
-clearAllImages()}
-window.addEventListener('beforeunload',cleanupOnUnload)
-window.addEventListener('pagehide',cleanupOnUnload)
-function updateImageCounter(){const countElement=document.getElementById('image-count')
-if(countElement){countElement.textContent=selectedImages.length}}
-function updateImagePreviewVisibility(){const container=document.getElementById('image-preview-container')
-if(!container)return
-if(selectedImages.length>0){container.classList.remove('hidden')
-container.classList.add('visible')}else{container.classList.add('hidden')
-container.classList.remove('visible')}}
-async function handleFileUpload(files){const fileArray=Array.from(files)
-const maxConcurrent=3
-let processed=0
-let successful=0
-if(fileArray.length>1){showStatus(`正在处理 ${fileArray.length} 个文件...`,'info')}
-for(let i=0;i<fileArray.length;i+=maxConcurrent){const batch=fileArray.slice(i,i+maxConcurrent)
-const batchPromises=batch.map(async file=>{try{const success=await addImageToList(file)
-if(success)successful++
-processed++
-if(fileArray.length>1){showStatus(`处理进度: ${processed}/${fileArray.length}`,'info')}
-return success}catch(error){console.error('文件处理失败:',file.name,error)
-processed++
-return false}})
-await Promise.all(batchPromises)
-if(i+maxConcurrent<fileArray.length){await new Promise(resolve=>setTimeout(resolve,50))}}
-updateImagePreviewVisibility()
-if(fileArray.length>1){showStatus(`完成处理: ${successful}/${fileArray.length} 个文件成功`,successful>0?'success':'error')}else if(fileArray.length===1){showStatus(successful>0?'文件处理成功':'文件处理失败',successful>0?'success':'error')}}
-function initializeDragAndDrop(){const textarea=document.getElementById('feedback-text')
-const dragOverlay=document.getElementById('drag-overlay')
-let dragCounter=0
-let dragTimer=null;['dragenter','dragover','dragleave','drop'].forEach(eventName=>{document.addEventListener(eventName,preventDefaults,{passive:false})})
-function preventDefaults(e){e.preventDefault()
-e.stopPropagation()}
-const throttledDragEnter=throttle(e=>{dragCounter++
-if(e.dataTransfer.types.includes('Files')){rafUpdate(()=>{dragOverlay.style.display='flex'
-textarea.classList.add('textarea-drag-over')})}},100)
-const throttledDragLeave=throttle(e=>{dragCounter--
-if(dragCounter<=0){dragCounter=0
-clearTimeout(dragTimer)
-dragTimer=setTimeout(()=>{rafUpdate(()=>{dragOverlay.style.display='none'
-textarea.classList.remove('textarea-drag-over')})},100)}},50)
-const throttledDragOver=throttle(e=>{if(e.dataTransfer.types.includes('Files')){e.dataTransfer.dropEffect='copy'}},50)
-document.addEventListener('dragenter',throttledDragEnter)
-document.addEventListener('dragleave',throttledDragLeave)
-document.addEventListener('dragover',throttledDragOver)
-document.addEventListener('drop',function(e){dragCounter=0
-clearTimeout(dragTimer)
-rafUpdate(()=>{dragOverlay.style.display='none'
-textarea.classList.remove('textarea-drag-over')})
-if(e.dataTransfer.files.length>0){const totalFiles=selectedImages.length+e.dataTransfer.files.length
-if(totalFiles>MAX_IMAGE_COUNT){showStatus(`最多只能上传 ${MAX_IMAGE_COUNT} 张图片`,'error')
-return}
-handleFileUpload(e.dataTransfer.files)}})}
-function initializePasteFunction(){const textarea=document.getElementById('feedback-text')
-const dataUriToFile=dataUri=>{try{const match=/^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/.exec(dataUri)
-if(!match)return null
-const mime=match[1]
-const base64=match[2].replace(/\s+/g,'')
-if(base64.length>15*1024*1024){console.warn('剪贴板图片过大（data uri），已跳过')
-return null}
-const binaryString=atob(base64)
-const bytes=new Uint8Array(binaryString.length)
-for(let i=0;i<binaryString.length;i++){bytes[i]=binaryString.charCodeAt(i)}
-let ext='png'
-if(mime==='image/jpeg')ext='jpg'
-else if(mime==='image/webp')ext='webp'
-else if(mime==='image/png')ext='png'
-const filename=`pasted-image-${Date.now()}.${ext}`
-return new File([bytes],filename,{type:mime,lastModified:Date.now()})}catch(err){console.warn('解析剪贴板 data uri 图片失败:',err)
-return null}}
-try{if(window.__aiInterventionAgentPasteHandler){document.removeEventListener('paste',window.__aiInterventionAgentPasteHandler)}}catch(_){}
-const pasteHandler=async function(e){const clipboardData=e.clipboardData
-if(!clipboardData)return
-if(!textarea||document.activeElement!==textarea)return
-const filesToAdd=[]
-const items=Array.from(clipboardData.items||[])
-for(const item of items){if(!item)continue
-if(item.kind!=='file')continue
-if(!item.type||!item.type.startsWith('image/'))continue
-const file=item.getAsFile()
-if(file)filesToAdd.push(file)}
-if(filesToAdd.length===0){const files=Array.from(clipboardData.files||[])
-for(const file of files){if(file&&file.type&&file.type.startsWith('image/')){filesToAdd.push(file)}}}
-if(filesToAdd.length===0){const html=clipboardData.getData('text/html')||''
-const text=clipboardData.getData('text/plain')||clipboardData.getData('text')||''
-const combined=`${html}\n${text}`
-const dataUriRegex=/data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=\s]+/g
-const matches=combined.match(dataUriRegex)||[]
-for(const dataUri of matches.slice(0,MAX_IMAGE_COUNT)){const file=dataUriToFile(dataUri)
-if(file)filesToAdd.push(file)}}
-if(filesToAdd.length===0)return
-const rawPastedText=clipboardData.getData('text/plain')||clipboardData.getData('text')||''
-const pastedText=rawPastedText.trim()
-const dataUriText=pastedText.replace(/\s+/g,'')
-const dataUriOnly=matches.length>0&&/^data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+$/i.test(dataUriText)
-if(!pastedText||dataUriOnly){e.preventDefault()}
-let added=0
-for(const file of filesToAdd){const ok=await addImageToList(file)
-if(ok)added++}
-updateImagePreviewVisibility()
-if(added>0){showStatus(`从剪贴板添加了 ${added} 张图片`,'success')}}
-window.__aiInterventionAgentPasteHandler=pasteHandler
-document.addEventListener('paste',pasteHandler)}
-function initializeFileSelection(){const fileInput=document.getElementById('file-upload-input')
-const uploadBtn=document.getElementById('upload-image-btn')
-uploadBtn.addEventListener('click',()=>{fileInput.click()})
-fileInput.addEventListener('change',e=>{if(e.target.files.length>0){handleFileUpload(e.target.files)
-e.target.value=''}})}
-function openImageModal(base64,name,size){const modal=document.getElementById('image-modal')
-const modalImage=document.getElementById('modal-image')
-const modalInfo=document.getElementById('modal-info')
-modalImage.src=base64
-modalImage.alt=name
-modalInfo.textContent=`${name} (${(size / 1024).toFixed(2)}KB)`
-modal.classList.add('show')
-document.addEventListener('keydown',handleModalKeydown)
-modal.addEventListener('click',function(e){if(e.target===modal){closeImageModal()}})}
-function closeImageModal(){const modal=document.getElementById('image-modal')
-modal.classList.remove('show')
-document.removeEventListener('keydown',handleModalKeydown)}
-function handleModalKeydown(event){if(event.key==='Escape'){closeImageModal()}}
-function isMobileDevice(){return(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)||(navigator.maxTouchPoints&&navigator.maxTouchPoints>2&&/MacIntel/.test(navigator.platform)))}
-function detectPlatform(){const platform=navigator.platform.toLowerCase()
-const userAgent=navigator.userAgent.toLowerCase()
-if(platform.includes('mac')||userAgent.includes('mac')){return'mac'}else if(platform.includes('win')||userAgent.includes('win')){return'windows'}else if(platform.includes('linux')||userAgent.includes('linux')){return'linux'}
-return'windows'}
-function getShortcutText(platform){const shortcuts={mac:['⌘+Enter  提交反馈','⌥+C      插入代码','⌘+V      粘贴图片','⌘+U      上传图片','Delete   清除图片'],windows:['Ctrl+Enter 提交反馈','Alt+C      插入代码','Ctrl+V     粘贴图片','Ctrl+U     上传图片','Delete     清除图片'],linux:['Ctrl+Enter 提交反馈','Alt+C      插入代码','Ctrl+V     粘贴图片','Ctrl+U     上传图片','Delete     清除图片']}
-const lines=shortcuts[platform]||shortcuts.windows
-return lines.join('\n')}
-function initializeShortcutTooltip(){if(!isMobileDevice()){const platform=detectPlatform()
-updateShortcutDisplay(platform)
-console.log(`检测到桌面平台: ${platform}，已设置对应快捷键`)}else{console.log('检测到移动设备，已隐藏快捷键部分')}}
-function updateShortcutDisplay(platform){const isMac=platform==='mac'
-const ctrlOrCmd=isMac?'Cmd':'Ctrl'
-const altOrOption=isMac?'Option':'Alt'
-const shortcuts={'shortcut-submit':`${ctrlOrCmd}+Enter`,'shortcut-code':`${altOrOption}+C`,'shortcut-paste':`${ctrlOrCmd}+V`,'shortcut-upload':`${ctrlOrCmd}+U`,'shortcut-delete':'Delete'}
-Object.entries(shortcuts).forEach(([id,shortcut])=>{const element=document.getElementById(id)
-if(element){element.textContent=shortcut}})}
-function checkBrowserCompatibility(){const features={fileAPI:!!(window.File&&window.FileReader&&window.FileList&&window.Blob),dragDrop:'ondragstart'in document.createElement('div'),canvas:!!document.createElement('canvas').getContext,webWorker:!!window.Worker,requestAnimationFrame:!!(window.requestAnimationFrame||window.webkitRequestAnimationFrame),objectURL:!!(window.URL&&window.URL.createObjectURL),clipboard:!!(navigator.clipboard&&navigator.clipboard.read)}
-console.log('浏览器兼容性检测:',features)
-if(!features.fileAPI){showStatus('您的浏览器不支持文件API，部分功能可能无法使用','warning')
-return false}
-if(!features.canvas){showStatus('您的浏览器不支持Canvas，图片压缩功能将被禁用','warning')}
-return true}
-function setupFeatureFallbacks(){if(!window.requestAnimationFrame){window.requestAnimationFrame=window.webkitRequestAnimationFrame||window.mozRequestAnimationFrame||window.oRequestAnimationFrame||window.msRequestAnimationFrame||function(callback){return setTimeout(callback,16)}}
-if(!navigator.clipboard){console.warn('剪贴板API不可用，使用降级方案')}
-if(!Object.assign){Object.assign=function(target,...sources){sources.forEach(source=>{if(source){Object.keys(source).forEach(key=>{target[key]=source[key]})}})
-return target}}}
-function initializeImageFeatures(){if(!checkBrowserCompatibility()){console.error('浏览器兼容性检查失败')
-return}
-setupFeatureFallbacks()
-try{initializeDragAndDrop()
-initializePasteFunction()
-initializeFileSelection()
-const clearBtn=document.getElementById('clear-all-images-btn')
-if(clearBtn){clearBtn.addEventListener('click',clearAllImages)}
-console.log('图片功能初始化完成')}catch(error){console.error('图片功能初始化失败:',error)
-showStatus('图片功能初始化失败，请刷新页面重试','error')}}
-function initializeApp(){initHourglassAnimation()
-loadConfig().then(()=>{console.log('✅ 配置加载完成')
-console.log('当前配置:',{has_content:config.has_content,persistent:config.persistent,prompt_length:config.prompt?config.prompt.length:0})
-if(typeof initMultiTaskSupport==='function'){initMultiTaskSupport()}}).catch(error=>{console.error('❌ 配置加载失败:',error)
-setTimeout(()=>{console.log('🔄 配置加载失败，延迟初始化多任务支持...')
-if(typeof initMultiTaskSupport==='function'){initMultiTaskSupport()}},3000)})
-initializeImageFeatures()
-startPeriodicCleanup()
-initializeShortcutTooltip()
-settingsManager.init().catch(error=>{console.warn('设置管理器初始化失败:',error)})
-notificationManager.init().then(()=>{console.log('通知管理器初始化完成')
-settingsManager.applySettings()}).catch(error=>{console.warn('通知管理器初始化失败:',error)})
-document.getElementById('insert-code-btn').addEventListener('click',insertCodeFromClipboard)
-document.getElementById('submit-btn').addEventListener('click',submitFeedback)
-document.getElementById('close-btn').addEventListener('click',closeInterface)
-const codePasteCloseBtn=document.getElementById('code-paste-close-btn')
-const codePasteCancelBtn=document.getElementById('code-paste-cancel-btn')
-const codePasteInsertBtn=document.getElementById('code-paste-insert-btn')
-const codePastePanel=document.getElementById('code-paste-panel')
-if(codePasteCloseBtn){codePasteCloseBtn.addEventListener('click',closeCodePasteModal)}
-if(codePasteCancelBtn){codePasteCancelBtn.addEventListener('click',closeCodePasteModal)}
-if(codePasteInsertBtn){codePasteInsertBtn.addEventListener('click',()=>{const textarea=document.getElementById('code-paste-textarea')
-const text=textarea?(textarea.value||''):''
-if(!text.trim()){showStatus('请输入要插入的代码','error')
-return}
-insertCodeBlockIntoFeedbackTextarea(text)
-closeCodePasteModal()})}
-if(codePastePanel){codePastePanel.addEventListener('click',function(e){if(e.target===codePastePanel){closeCodePasteModal()}})}
-document.addEventListener('keydown',event=>{const isMac=detectPlatform()==='mac'
-const ctrlOrCmd=isMac?event.metaKey:event.ctrlKey
-const altOrOption=isMac?event.altKey:event.altKey
-if(ctrlOrCmd&&event.key==='Enter'){event.preventDefault()
-submitFeedback()}else if(altOrOption&&event.key==='c'){event.preventDefault()
-insertCodeFromClipboard()}else if(ctrlOrCmd&&event.key==='v'){console.log(`快捷键: ${isMac ? 'Cmd' : 'Ctrl'}+V 粘贴`)}else if(ctrlOrCmd&&event.key==='u'){event.preventDefault()
-document.getElementById('upload-image-btn').click()
-console.log(`快捷键: ${isMac ? 'Cmd' : 'Ctrl'}+U 上传图片`)}else if(event.key==='Delete'&&selectedImages.length>0){event.preventDefault()
-clearAllImages()
-console.log('快捷键: Delete 清除所有图片')}else if(ctrlOrCmd&&event.shiftKey&&event.key==='N'){event.preventDefault()
-testNotification()
-console.log(`快捷键: ${isMac ? 'Cmd' : 'Ctrl'}+Shift+N 测试通知`)}})
-function enableAudioOnFirstInteraction(){if(notificationManager.audioContext&&notificationManager.audioContext.state==='suspended'){notificationManager.audioContext.resume().then(()=>{console.log('音频上下文已启用')}).catch(error=>{console.warn('启用音频上下文失败:',error)})}}
-document.addEventListener('click',enableAudioOnFirstInteraction,{once:true})
-document.addEventListener('keydown',enableAudioOnFirstInteraction,{once:true})
-document.addEventListener('touchstart',enableAudioOnFirstInteraction,{once:true})
-async function testNotification(){try{await notificationManager.sendNotification('通知测试','这是一个测试通知，用于验证通知功能是否正常工作',{tag:'test-notification',requireInteraction:false})
-showStatus('测试通知已发送','success')}catch(error){console.error('测试通知失败:',error)
-showStatus('测试通知失败','error')}}}
-if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',initializeApp)}else{initializeApp()}
+                )}MB，将返回当前压缩版本`
+              )
+              logCompression(blob, finalName)
+              resolve(compressedFile)
+              return
+            }
+
+            // 优先降低质量（对 webp/jpeg 有效）；质量到底后再缩小尺寸
+            if (quality > 0.55) {
+              quality = Math.max(0.55, quality - 0.1)
+              return tryToBlob(0)
+            }
+
+            const nextWidth = Math.max(320, Math.floor(currentWidth * 0.85))
+            const nextHeight = Math.max(320, Math.floor(currentHeight * 0.85))
+            if (nextWidth === currentWidth && nextHeight === currentHeight) {
+              logCompression(blob, finalName)
+              resolve(compressedFile)
+              return
+            }
+
+            currentWidth = nextWidth
+            currentHeight = nextHeight
+            canvas.width = currentWidth
+            canvas.height = currentHeight
+            ctx.imageSmoothingEnabled = true
+            ctx.imageSmoothingQuality = 'high'
+
+            rafUpdate(() => {
+              ctx.drawImage(img, 0, 0, currentWidth, currentHeight)
+              tryToBlob(0)
+            })
+          },
+          outType,
+          quality
+        )
+      }
+
+      // 首次绘制后即可释放 ObjectURL（后续仅使用已加载的 img + canvas）
+      rafUpdate(() => {
+        ctx.drawImage(img, 0, 0, currentWidth, currentHeight)
+        revokeObjectURL(objectURL)
+        tryToBlob(0)
+      })
+    }
+
+    img.onerror = () => {
+      revokeObjectURL(objectURL)
+      resolve(file)
+    }
+
+    img.src = objectURL
+  })
+}
+
+// 添加图片到列表
+async function addImageToList(file) {
+  // 验证图片数量
+  if (selectedImages.length >= MAX_IMAGE_COUNT) {
+    showStatus(`最多只能上传 ${MAX_IMAGE_COUNT} 张图片`, 'error')
+    return false
+  }
+
+  // 验证文件
+  const errors = validateImageFile(file)
+  if (errors.length > 0) {
+    showStatus(errors.join('; '), 'error')
+    return false
+  }
+
+  // 检查是否已经添加过相同文件
+  const isDuplicate = selectedImages.some(
+    img =>
+      img.name === file.name && img.size === file.size && img.lastModified === file.lastModified
+  )
+  if (isDuplicate) {
+    showStatus('该图片已经添加过了', 'error')
+    return false
+  }
+
+  // 预先生成 ID，确保 catch 分支也能安全引用
+  const imageId = Date.now() + Math.random()
+
+  try {
+    // 创建加载占位符
+    const timestamp = Date.now()
+    const imageItem = {
+      id: imageId,
+      file: file,
+      name: file.name,
+      size: file.size,
+      base64: null,
+      timestamp: timestamp,
+      lastModified: file.lastModified
+    }
+
+    selectedImages.push(imageItem)
+    renderImagePreview(imageItem, true) // true表示显示加载状态
+    updateImageCounter()
+
+    // 压缩图片（如果需要）
+    const processedFile = await compressImage(file)
+
+    // 更新文件信息
+    imageItem.file = processedFile
+    imageItem.size = processedFile.size
+
+    // 创建安全的预览 URL
+    const previewUrl = createObjectURL(processedFile)
+    if (previewUrl) {
+      imageItem.previewUrl = previewUrl
+    } else {
+      throw new Error('创建预览URL失败')
+    }
+
+    // 更新预览
+    renderImagePreview(imageItem, false)
+
+    console.log('图片添加成功:', file.name, `(${(imageItem.size / 1024).toFixed(2)}KB)`)
+    return true
+  } catch (error) {
+    console.error('图片处理失败:', error)
+    showStatus('图片处理失败: ' + error.message, 'error')
+
+    // 释放可能已创建的预览 URL
+    try {
+      const failed = selectedImages.find(img => img.id === imageId)
+      if (failed && failed.previewUrl && failed.previewUrl.startsWith('blob:')) {
+        revokeObjectURL(failed.previewUrl)
+      }
+    } catch (_) {
+      // ignore
+    }
+
+    // 从列表中移除失败的图片
+    selectedImages = selectedImages.filter(img => img.id !== imageId)
+    const previewElement = document.getElementById(`preview-${imageId}`)
+    if (previewElement) {
+      previewElement.remove()
+    }
+    updateImageCounter()
+    updateImagePreviewVisibility()
+    return false
+  }
+}
+
+// 批量DOM更新队列
+let domUpdateQueue = []
+let domUpdateScheduled = false
+
+// 批量处理DOM更新
+function scheduleDOMUpdate(callback) {
+  domUpdateQueue.push(callback)
+  if (!domUpdateScheduled) {
+    domUpdateScheduled = true
+    rafUpdate(() => {
+      const fragment = document.createDocumentFragment()
+      domUpdateQueue.forEach(callback => callback(fragment))
+      domUpdateQueue = []
+      domUpdateScheduled = false
+    })
+  }
+}
+
+// 优化的图片预览渲染
+function renderImagePreview(imageItem, isLoading = false) {
+  rafUpdate(() => {
+    const previewContainer = document.getElementById('image-previews')
+    if (!previewContainer) {
+      console.error('图片预览容器 #image-previews 未找到，无法渲染预览')
+      return
+    }
+    let previewElement = document.getElementById(`preview-${imageItem.id}`)
+
+    if (!previewElement) {
+      previewElement = document.createElement('div')
+      previewElement.id = `preview-${imageItem.id}`
+      previewElement.className = 'image-preview-item'
+      previewContainer.appendChild(previewElement)
+    }
+
+    // 将 createImagePreview() 生成的 DOM 安全地“解包”到现有容器中
+    // 注意：.hidden 使用了 !important，且我们复用已有的 previewElement（保持 id/class 不变）
+    const replacePreviewChildren = (container, built) => {
+      const fragment = document.createDocumentFragment()
+      while (built.firstChild) {
+        fragment.appendChild(built.firstChild)
+      }
+      DOMSecurity.replaceContent(container, fragment)
+    }
+
+    // 使用安全的图片预览创建方法
+    const newPreviewElement = DOMSecurity.createImagePreview(imageItem, isLoading)
+    replacePreviewChildren(previewElement, newPreviewElement)
+
+    if (!isLoading && imageItem.previewUrl) {
+      // 延迟加载图片以优化性能
+      const img = new Image()
+      img.onload = () => {
+        rafUpdate(() => {
+          const updatedPreviewElement = DOMSecurity.createImagePreview(imageItem, false)
+          replacePreviewChildren(previewElement, updatedPreviewElement)
+        })
+      }
+      img.src = imageItem.previewUrl
+    }
+  })
+}
+
+// 文本安全化函数，防止XSS
+function sanitizeText(text) {
+  const div = document.createElement('div')
+  div.textContent = text
+  return div.innerHTML
+}
+
+// 删除图片
+function removeImage(imageId) {
+  // 找到要删除的图片并安全释放 URL
+  const imageToRemove = selectedImages.find(img => img.id == imageId)
+  if (imageToRemove && imageToRemove.previewUrl && imageToRemove.previewUrl.startsWith('blob:')) {
+    revokeObjectURL(imageToRemove.previewUrl)
+  }
+
+  selectedImages = selectedImages.filter(img => img.id != imageId)
+  const previewElement = document.getElementById(`preview-${imageId}`)
+  if (previewElement) {
+    previewElement.remove()
+  }
+  updateImageCounter()
+  updateImagePreviewVisibility()
+}
+
+// 清除所有图片
+function clearAllImages() {
+  // 清理内存中的 Object URLs
+  selectedImages.forEach(img => {
+    if (img.previewUrl && img.previewUrl.startsWith('blob:')) {
+      revokeObjectURL(img.previewUrl)
+    }
+  })
+
+  selectedImages = []
+  const previewContainer = document.getElementById('image-previews')
+  // 安全清空容器内容
+  DOMSecurity.clearContent(previewContainer)
+  updateImageCounter()
+  updateImagePreviewVisibility()
+
+  // 强制垃圾回收提示（仅在开发环境）
+  if (window.gc && typeof window.gc === 'function') {
+    setTimeout(() => window.gc(), 1000)
+  }
+
+  console.log('所有图片已清除，内存已释放')
+}
+
+// 页面卸载时的清理
+function cleanupOnUnload() {
+  // 清理 Lottie 动画实例（避免在页面卸载过程中仍占用定时器/RAF）
+  try {
+    if (hourglassAnimation) {
+      hourglassAnimation.destroy()
+      hourglassAnimation = null
+    }
+  } catch (e) {
+    // ignore
+  }
+  try {
+    const container = document.getElementById('hourglass-lottie')
+    if (container) container.textContent = ''
+  } catch (e) {
+    // ignore
+  }
+
+  cleanupAllObjectURLs()
+  clearAllImages()
+}
+
+// 监听页面卸载事件
+window.addEventListener('beforeunload', cleanupOnUnload)
+window.addEventListener('pagehide', cleanupOnUnload)
+
+// 更新图片计数
+function updateImageCounter() {
+  const countElement = document.getElementById('image-count')
+  if (countElement) {
+    countElement.textContent = selectedImages.length
+  }
+}
+
+// 更新图片预览区域可见性
+function updateImagePreviewVisibility() {
+  const container = document.getElementById('image-preview-container')
+  if (!container) return
+
+  // 注意：.hidden 使用了 display:none !important，不能用 style.display 覆盖
+  if (selectedImages.length > 0) {
+    container.classList.remove('hidden')
+    container.classList.add('visible')
+  } else {
+    container.classList.add('hidden')
+    container.classList.remove('visible')
+  }
+}
+
+// 优化的批量文件处理
+async function handleFileUpload(files) {
+  const fileArray = Array.from(files)
+  const maxConcurrent = 3 // 限制并发处理数量
+  let processed = 0
+  let successful = 0
+
+  // 显示批量处理进度
+  if (fileArray.length > 1) {
+    showStatus(`正在处理 ${fileArray.length} 个文件...`, 'info')
+  }
+
+  // 分批处理文件，避免内存溢出
+  for (let i = 0; i < fileArray.length; i += maxConcurrent) {
+    const batch = fileArray.slice(i, i + maxConcurrent)
+
+    const batchPromises = batch.map(async file => {
+      try {
+        const success = await addImageToList(file)
+        if (success) successful++
+        processed++
+
+        // 更新进度
+        if (fileArray.length > 1) {
+          showStatus(`处理进度: ${processed}/${fileArray.length}`, 'info')
+        }
+
+        return success
+      } catch (error) {
+        console.error('文件处理失败:', file.name, error)
+        processed++
+        return false
+      }
+    })
+
+    // 等待当前批次完成
+    await Promise.all(batchPromises)
+
+    // 批次间添加小延迟，避免阻塞UI
+    if (i + maxConcurrent < fileArray.length) {
+      await new Promise(resolve => setTimeout(resolve, 50))
+    }
+  }
+
+  updateImagePreviewVisibility()
+
+  // 显示最终结果
+  if (fileArray.length > 1) {
+    showStatus(
+      `完成处理: ${successful}/${fileArray.length} 个文件成功`,
+      successful > 0 ? 'success' : 'error'
+    )
+  } else if (fileArray.length === 1) {
+    showStatus(
+      successful > 0 ? '文件处理成功' : '文件处理失败',
+      successful > 0 ? 'success' : 'error'
+    )
+  }
+}
+
+// 优化的拖放功能实现
+function initializeDragAndDrop() {
+  const textarea = document.getElementById('feedback-text')
+  const dragOverlay = document.getElementById('drag-overlay')
+  let dragCounter = 0
+  let dragTimer = null
+
+  // 阻止默认的拖放行为
+  ;['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+    document.addEventListener(eventName, preventDefaults, { passive: false })
+  })
+
+  function preventDefaults(e) {
+    e.preventDefault()
+    e.stopPropagation()
+  }
+
+  // 节流的拖拽处理函数
+  const throttledDragEnter = throttle(e => {
+    dragCounter++
+    if (e.dataTransfer.types.includes('Files')) {
+      rafUpdate(() => {
+        dragOverlay.style.display = 'flex'
+        textarea.classList.add('textarea-drag-over')
+      })
+    }
+  }, 100)
+
+  const throttledDragLeave = throttle(e => {
+    dragCounter--
+    if (dragCounter <= 0) {
+      dragCounter = 0
+      clearTimeout(dragTimer)
+      dragTimer = setTimeout(() => {
+        rafUpdate(() => {
+          dragOverlay.style.display = 'none'
+          textarea.classList.remove('textarea-drag-over')
+        })
+      }, 100)
+    }
+  }, 50)
+
+  const throttledDragOver = throttle(e => {
+    if (e.dataTransfer.types.includes('Files')) {
+      e.dataTransfer.dropEffect = 'copy'
+    }
+  }, 50)
+
+  // 拖拽事件监听
+  document.addEventListener('dragenter', throttledDragEnter)
+  document.addEventListener('dragleave', throttledDragLeave)
+  document.addEventListener('dragover', throttledDragOver)
+
+  // 拖拽放下
+  document.addEventListener('drop', function (e) {
+    dragCounter = 0
+    clearTimeout(dragTimer)
+
+    rafUpdate(() => {
+      dragOverlay.style.display = 'none'
+      textarea.classList.remove('textarea-drag-over')
+    })
+
+    if (e.dataTransfer.files.length > 0) {
+      // 验证文件数量限制
+      const totalFiles = selectedImages.length + e.dataTransfer.files.length
+      if (totalFiles > MAX_IMAGE_COUNT) {
+        showStatus(`最多只能上传 ${MAX_IMAGE_COUNT} 张图片`, 'error')
+        return
+      }
+
+      handleFileUpload(e.dataTransfer.files)
+    }
+  })
+}
+
+// 粘贴功能实现
+function initializePasteFunction() {
+  const textarea = document.getElementById('feedback-text')
+
+  // data:image/*;base64,xxxx → File
+  const dataUriToFile = dataUri => {
+    try {
+      const match = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/.exec(dataUri)
+      if (!match) return null
+
+      const mime = match[1]
+      const base64 = match[2].replace(/\s+/g, '')
+
+      // 安全限制：避免极端大 data uri 卡死页面（阈值约 15MB base64）
+      if (base64.length > 15 * 1024 * 1024) {
+        console.warn('剪贴板图片过大（data uri），已跳过')
+        return null
+      }
+
+      const binaryString = atob(base64)
+      const bytes = new Uint8Array(binaryString.length)
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i)
+      }
+
+      let ext = 'png'
+      if (mime === 'image/jpeg') ext = 'jpg'
+      else if (mime === 'image/webp') ext = 'webp'
+      else if (mime === 'image/png') ext = 'png'
+      const filename = `pasted-image-${Date.now()}.${ext}`
+      return new File([bytes], filename, { type: mime, lastModified: Date.now() })
+    } catch (err) {
+      console.warn('解析剪贴板 data uri 图片失败:', err)
+      return null
+    }
+  }
+
+  // 防重复注册：
+  // 某些场景下（例如脚本被重复执行、或初始化函数被重复调用），会导致 paste 监听器被注册多次，
+  // 从而出现“粘贴一次添加两张重复图片”的问题。这里通过“先移除旧 handler，再注册新 handler”保证幂等。
+  try {
+    if (window.__aiInterventionAgentPasteHandler) {
+      document.removeEventListener('paste', window.__aiInterventionAgentPasteHandler)
+    }
+  } catch (_) {
+    // ignore
+  }
+
+  const pasteHandler = async function (e) {
+    const clipboardData = e.clipboardData
+    if (!clipboardData) return
+
+    // 仅在“反馈文本框”聚焦时处理图片粘贴（避免影响其他输入场景）
+    if (!textarea || document.activeElement !== textarea) return
+
+    const filesToAdd = []
+
+    // 方案 A：优先从 clipboardData.items 获取图片文件（大多数桌面浏览器）
+    const items = Array.from(clipboardData.items || [])
+    for (const item of items) {
+      if (!item) continue
+      if (item.kind !== 'file') continue
+      if (!item.type || !item.type.startsWith('image/')) continue
+
+      const file = item.getAsFile()
+      if (file) filesToAdd.push(file)
+    }
+
+    // 方案 B：部分浏览器只在 clipboardData.files 暴露文件
+    // 注意：很多浏览器同时在 items 和 files 中暴露同一张图片。
+    // 若我们两边都收集，会导致“一次粘贴出现两张重复图片”。
+    // 因此仅当方案 A 没拿到图片时，才回退到 files。
+    if (filesToAdd.length === 0) {
+      const files = Array.from(clipboardData.files || [])
+      for (const file of files) {
+        if (file && file.type && file.type.startsWith('image/')) {
+          filesToAdd.push(file)
+        }
+      }
+    }
+
+    // 方案 C：兜底解析 text/html 或 text/plain 中的 data:image;base64（某些移动端/特殊场景）
+    if (filesToAdd.length === 0) {
+      const html = clipboardData.getData('text/html') || ''
+      const text = clipboardData.getData('text/plain') || clipboardData.getData('text') || ''
+      const combined = `${html}\n${text}`
+
+      const dataUriRegex = /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=\s]+/g
+      const matches = combined.match(dataUriRegex) || []
+
+      for (const dataUri of matches.slice(0, MAX_IMAGE_COUNT)) {
+        const file = dataUriToFile(dataUri)
+        if (file) filesToAdd.push(file)
+      }
+    }
+
+    if (filesToAdd.length === 0) return
+
+    // 如果剪贴板同时有文本内容，尽量不阻止默认粘贴（让文本正常进入 textarea）
+    const rawPastedText = clipboardData.getData('text/plain') || clipboardData.getData('text') || ''
+    const pastedText = rawPastedText.trim()
+    const dataUriText = pastedText.replace(/\s+/g, '')
+    const dataUriOnly =
+      matches.length > 0 &&
+      /^data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+$/i.test(dataUriText)
+
+    if (!pastedText || dataUriOnly) {
+      e.preventDefault()
+    }
+
+    let added = 0
+    for (const file of filesToAdd) {
+      const ok = await addImageToList(file)
+      if (ok) added++
+    }
+
+    updateImagePreviewVisibility()
+    if (added > 0) {
+      showStatus(`从剪贴板添加了 ${added} 张图片`, 'success')
+    }
+  }
+
+  window.__aiInterventionAgentPasteHandler = pasteHandler
+  document.addEventListener('paste', pasteHandler)
+}
+
+// 文件选择功能
+function initializeFileSelection() {
+  const fileInput = document.getElementById('file-upload-input')
+  const uploadBtn = document.getElementById('upload-image-btn')
+
+  uploadBtn.addEventListener('click', () => {
+    fileInput.click()
+  })
+
+  fileInput.addEventListener('change', e => {
+    if (e.target.files.length > 0) {
+      handleFileUpload(e.target.files)
+      // 清空input，允许重复选择相同文件
+      e.target.value = ''
+    }
+  })
+}
+
+// 图片模态框功能
+function openImageModal(base64, name, size) {
+  const modal = document.getElementById('image-modal')
+  const modalImage = document.getElementById('modal-image')
+  const modalInfo = document.getElementById('modal-info')
+
+  modalImage.src = base64
+  modalImage.alt = name
+  modalInfo.textContent = `${name} (${(size / 1024).toFixed(2)}KB)`
+
+  modal.classList.add('show')
+
+  // 添加键盘事件监听
+  document.addEventListener('keydown', handleModalKeydown)
+
+  // 点击模态框背景关闭
+  modal.addEventListener('click', function (e) {
+    if (e.target === modal) {
+      closeImageModal()
+    }
+  })
+}
+
+function closeImageModal() {
+  const modal = document.getElementById('image-modal')
+  modal.classList.remove('show')
+
+  // 移除键盘事件监听
+  document.removeEventListener('keydown', handleModalKeydown)
+}
+
+function handleModalKeydown(event) {
+  if (event.key === 'Escape') {
+    closeImageModal()
+  }
+}
+
+// 移动设备检测
+function isMobileDevice() {
+  return (
+    /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ||
+    (navigator.maxTouchPoints &&
+      navigator.maxTouchPoints > 2 &&
+      /MacIntel/.test(navigator.platform))
+  )
+}
+
+// 平台检测和快捷键设置
+function detectPlatform() {
+  const platform = navigator.platform.toLowerCase()
+  const userAgent = navigator.userAgent.toLowerCase()
+
+  if (platform.includes('mac') || userAgent.includes('mac')) {
+    return 'mac'
+  } else if (platform.includes('win') || userAgent.includes('win')) {
+    return 'windows'
+  } else if (platform.includes('linux') || userAgent.includes('linux')) {
+    return 'linux'
+  }
+  return 'windows' // 默认为Windows
+}
+
+function getShortcutText(platform) {
+  const shortcuts = {
+    mac: [
+      '⌘+Enter  提交反馈',
+      '⌥+C      插入代码',
+      '⌘+V      粘贴图片',
+      '⌘+U      上传图片',
+      'Delete   清除图片'
+    ],
+    windows: [
+      'Ctrl+Enter 提交反馈',
+      'Alt+C      插入代码',
+      'Ctrl+V     粘贴图片',
+      'Ctrl+U     上传图片',
+      'Delete     清除图片'
+    ],
+    linux: [
+      'Ctrl+Enter 提交反馈',
+      'Alt+C      插入代码',
+      'Ctrl+V     粘贴图片',
+      'Ctrl+U     上传图片',
+      'Delete     清除图片'
+    ]
+  }
+
+  const lines = shortcuts[platform] || shortcuts.windows
+  return lines.join('\n')
+}
+
+function initializeShortcutTooltip() {
+  // 桌面设备显示快捷键信息
+  if (!isMobileDevice()) {
+    const platform = detectPlatform()
+    updateShortcutDisplay(platform)
+    console.log(`检测到桌面平台: ${platform}，已设置对应快捷键`)
+  } else {
+    console.log('检测到移动设备，已隐藏快捷键部分')
+  }
+}
+
+function updateShortcutDisplay(platform) {
+  const isMac = platform === 'mac'
+  const ctrlOrCmd = isMac ? 'Cmd' : 'Ctrl'
+  const altOrOption = isMac ? 'Option' : 'Alt'
+
+  // 更新各个快捷键显示
+  const shortcuts = {
+    'shortcut-submit': `${ctrlOrCmd}+Enter`,
+    'shortcut-code': `${altOrOption}+C`,
+    'shortcut-paste': `${ctrlOrCmd}+V`,
+    'shortcut-upload': `${ctrlOrCmd}+U`,
+    'shortcut-delete': 'Delete'
+  }
+
+  Object.entries(shortcuts).forEach(([id, shortcut]) => {
+    const element = document.getElementById(id)
+    if (element) {
+      element.textContent = shortcut
+    }
+  })
+}
+
+// 浏览器兼容性检测
+function checkBrowserCompatibility() {
+  const features = {
+    fileAPI: !!(window.File && window.FileReader && window.FileList && window.Blob),
+    dragDrop: 'ondragstart' in document.createElement('div'),
+    canvas: !!document.createElement('canvas').getContext,
+    webWorker: !!window.Worker,
+    requestAnimationFrame: !!(window.requestAnimationFrame || window.webkitRequestAnimationFrame),
+    objectURL: !!(window.URL && window.URL.createObjectURL),
+    clipboard: !!(navigator.clipboard && navigator.clipboard.read)
+  }
+
+  console.log('浏览器兼容性检测:', features)
+
+  // 关键功能检查
+  if (!features.fileAPI) {
+    showStatus('您的浏览器不支持文件API，部分功能可能无法使用', 'warning')
+    return false
+  }
+
+  if (!features.canvas) {
+    showStatus('您的浏览器不支持Canvas，图片压缩功能将被禁用', 'warning')
+  }
+
+  return true
+}
+
+// 特性降级处理
+function setupFeatureFallbacks() {
+  // RAF降级
+  if (!window.requestAnimationFrame) {
+    window.requestAnimationFrame =
+      window.webkitRequestAnimationFrame ||
+      window.mozRequestAnimationFrame ||
+      window.oRequestAnimationFrame ||
+      window.msRequestAnimationFrame ||
+      function (callback) {
+        return setTimeout(callback, 16)
+      }
+  }
+
+  // 复制API降级
+  if (!navigator.clipboard) {
+    console.warn('剪贴板API不可用，使用降级方案')
+  }
+
+  // Object.assign降级
+  if (!Object.assign) {
+    Object.assign = function (target, ...sources) {
+      sources.forEach(source => {
+        if (source) {
+          Object.keys(source).forEach(key => {
+            target[key] = source[key]
+          })
+        }
+      })
+      return target
+    }
+  }
+}
+
+// 初始化图片功能
+function initializeImageFeatures() {
+  // 兼容性检查
+  if (!checkBrowserCompatibility()) {
+    console.error('浏览器兼容性检查失败')
+    return
+  }
+
+  // 设置降级处理
+  setupFeatureFallbacks()
+
+  try {
+    initializeDragAndDrop()
+    initializePasteFunction()
+    initializeFileSelection()
+
+    // 清除所有图片按钮事件
+    const clearBtn = document.getElementById('clear-all-images-btn')
+    if (clearBtn) {
+      clearBtn.addEventListener('click', clearAllImages)
+    }
+
+    console.log('图片功能初始化完成')
+  } catch (error) {
+    console.error('图片功能初始化失败:', error)
+    showStatus('图片功能初始化失败，请刷新页面重试', 'error')
+  }
+}
+
+// 事件监听器 - 兼容 DOM 已加载完成的情况
+function initializeApp() {
+  // 初始化 Lottie 沙漏动画
+  initHourglassAnimation()
+
+  loadConfig()
+    .then(() => {
+      // 配置加载完成
+      console.log('配置加载完成')
+      console.log('当前配置:', {
+        has_content: config.has_content,
+        persistent: config.persistent,
+        prompt_length: config.prompt ? config.prompt.length : 0
+      })
+
+      // 【优化】停用 app.js 内容轮询，使用 multi_task.js 的任务轮询统一管理
+      // 原因：两个轮询系统会导致 textarea 内容被意外清空
+      // startContentPolling() // 已停用
+
+      // 初始化多任务支持（内含任务轮询）
+      if (typeof initMultiTaskSupport === 'function') {
+        initMultiTaskSupport()
+      }
+    })
+    .catch(error => {
+      console.error('配置加载失败:', error)
+      // 即使配置加载失败，也尝试初始化多任务支持
+      setTimeout(() => {
+        console.log('配置加载失败，延迟初始化多任务支持...')
+        // startContentPolling() // 已停用
+
+        // 初始化多任务支持（内含任务轮询）
+        if (typeof initMultiTaskSupport === 'function') {
+          initMultiTaskSupport()
+        }
+      }, 3000)
+    })
+
+  // 初始化图片功能
+  initializeImageFeatures()
+
+  // 启动 URL 对象定期清理
+  startPeriodicCleanup()
+
+  // 初始化快捷键提示
+  initializeShortcutTooltip()
+
+  // 初始化设置管理器并在其配置就绪后再启动通知管理器
+  settingsManager
+    .init()
+    .then(() => {
+      settingsManager.applySettings({ syncBackend: false })
+      return notificationManager.init()
+    })
+    .then(() => {
+      console.log('通知管理器初始化完成')
+    })
+    .catch(error => {
+      console.warn('设置或通知管理器初始化失败:', error)
+    })
+
+  // 按钮事件
+  document.getElementById('insert-code-btn').addEventListener('click', insertCodeFromClipboard)
+  document.getElementById('submit-btn').addEventListener('click', submitFeedback)
+  document.getElementById('close-btn').addEventListener('click', closeInterface)
+
+  // 代码粘贴模态框按钮事件
+  const codePasteCloseBtn = document.getElementById('code-paste-close-btn')
+  const codePasteCancelBtn = document.getElementById('code-paste-cancel-btn')
+  const codePasteInsertBtn = document.getElementById('code-paste-insert-btn')
+  const codePastePanel = document.getElementById('code-paste-panel')
+
+  if (codePasteCloseBtn) {
+    codePasteCloseBtn.addEventListener('click', closeCodePasteModal)
+  }
+  if (codePasteCancelBtn) {
+    codePasteCancelBtn.addEventListener('click', closeCodePasteModal)
+  }
+  if (codePasteInsertBtn) {
+    codePasteInsertBtn.addEventListener('click', () => {
+      const textarea = document.getElementById('code-paste-textarea')
+      const text = textarea ? (textarea.value || '') : ''
+      if (!text.trim()) {
+        showStatus('请输入要插入的代码', 'error')
+        return
+      }
+      insertCodeBlockIntoFeedbackTextarea(text)
+      closeCodePasteModal()
+    })
+  }
+  if (codePastePanel) {
+    codePastePanel.addEventListener('click', function (e) {
+      if (e.target === codePastePanel) {
+        closeCodePasteModal()
+      }
+    })
+  }
+
+  // 键盘快捷键 - 支持跨平台
+  document.addEventListener('keydown', event => {
+    const isMac = detectPlatform() === 'mac'
+    const ctrlOrCmd = isMac ? event.metaKey : event.ctrlKey
+    const altOrOption = isMac ? event.altKey : event.altKey
+
+    if (ctrlOrCmd && event.key === 'Enter') {
+      event.preventDefault()
+      submitFeedback()
+    } else if (altOrOption && event.key === 'c') {
+      event.preventDefault()
+      insertCodeFromClipboard()
+    } else if (ctrlOrCmd && event.key === 'v') {
+      // Ctrl/Cmd+V 粘贴图片 - 浏览器默认处理，我们只在paste事件中处理
+      console.log(`快捷键: ${isMac ? 'Cmd' : 'Ctrl'}+V 粘贴`)
+    } else if (ctrlOrCmd && event.key === 'u') {
+      event.preventDefault()
+      document.getElementById('upload-image-btn').click()
+      console.log(`快捷键: ${isMac ? 'Cmd' : 'Ctrl'}+U 上传图片`)
+    } else if (event.key === 'Delete' && selectedImages.length > 0) {
+      event.preventDefault()
+      clearAllImages()
+      console.log('快捷键: Delete 清除所有图片')
+    } else if (ctrlOrCmd && event.shiftKey && event.key === 'N') {
+      // Ctrl+Shift+N 测试通知
+      event.preventDefault()
+      testNotification()
+      console.log(`快捷键: ${isMac ? 'Cmd' : 'Ctrl'}+Shift+N 测试通知`)
+    }
+  })
+
+  // 用户首次交互时启用音频上下文
+  function enableAudioOnFirstInteraction() {
+    if (
+      notificationManager.audioContext &&
+      notificationManager.audioContext.state === 'suspended'
+    ) {
+      notificationManager.audioContext
+        .resume()
+        .then(() => {
+          console.log('音频上下文已启用')
+        })
+        .catch(error => {
+          console.warn('启用音频上下文失败:', error)
+        })
+    }
+  }
+
+  // 添加首次交互监听器
+  document.addEventListener('click', enableAudioOnFirstInteraction, { once: true })
+  document.addEventListener('keydown', enableAudioOnFirstInteraction, { once: true })
+  document.addEventListener('touchstart', enableAudioOnFirstInteraction, { once: true })
+
+  // 测试通知功能
+  async function testNotification() {
+    try {
+      await notificationManager.sendNotification(
+        '通知测试',
+        '这是一个测试通知，用于验证通知功能是否正常工作',
+        {
+          tag: 'test-notification',
+          requireInteraction: false
+        }
+      )
+      showStatus('测试通知已发送', 'success')
+    } catch (error) {
+      console.error('测试通知失败:', error)
+      showStatus('测试通知失败', 'error')
+    }
+  }
+}
+
+// 兼容 DOM 已加载和未加载两种情况
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initializeApp)
+} else {
+  // DOM 已加载完成，立即执行
+  initializeApp()
+}

--- a/static/js/app.min.js
+++ b/static/js/app.min.js
@@ -1145,6 +1145,11 @@ class NotificationManager {
         }
 
         console.log(`通知权限状态: ${this.permission}`)
+        window.dispatchEvent(
+          new CustomEvent('notification-permission-changed', {
+            detail: { permission: this.permission }
+          })
+        )
         return this.permission === 'granted'
       })()
 
@@ -2060,6 +2065,10 @@ class SettingsManager {
       } else if (e.target.id === 'bark-action') {
         this.updateSetting('barkAction', e.target.value)
       }
+    })
+
+    window.addEventListener('notification-permission-changed', () => {
+      this.updateStatus()
     })
   }
 

--- a/static/js/keyboard-shortcuts.js
+++ b/static/js/keyboard-shortcuts.js
@@ -334,7 +334,7 @@ const KeyboardShortcuts = (function () {
 
       const helpText = `
 ╔══════════════════════════════════════╗
-║       ⌨️ 键盘快捷键帮助             ║
+║         键盘快捷键帮助             ║
 ╠══════════════════════════════════════╣
 ║  ${mod}+Enter    提交反馈              ║
 ║  ${mod}+,        打开设置              ║
@@ -351,7 +351,7 @@ const KeyboardShortcuts = (function () {
       // 显示提示通知
       if (typeof notificationManager !== 'undefined') {
         notificationManager.sendNotification(
-          '⌨️ 快捷键',
+          '快捷键',
           `${mod}+Enter 提交 | T 切换主题 | Esc 关闭弹窗`,
           { tag: 'keyboard-help', requireInteraction: false }
         );

--- a/static/js/keyboard-shortcuts.min.js
+++ b/static/js/keyboard-shortcuts.min.js
@@ -1,17 +1,340 @@
-const KeyboardShortcuts=(function(){'use strict';const MODIFIER_KEYS={ctrl:'ctrlKey',alt:'altKey',shift:'shiftKey',meta:'metaKey',cmd:'metaKey',command:'metaKey',option:'altKey'};const KEY_ALIASES={'esc':'Escape','escape':'Escape','enter':'Enter','return':'Enter','space':' ','spacebar':' ','up':'ArrowUp','down':'ArrowDown','left':'ArrowLeft','right':'ArrowRight','delete':'Delete','del':'Delete','backspace':'Backspace','tab':'Tab','home':'Home','end':'End','pageup':'PageUp','pagedown':'PageDown'};const IGNORED_ELEMENTS=['INPUT','TEXTAREA','SELECT'];const shortcuts=new Map();let initialized=false;function parseShortcut(shortcut){const parts=shortcut.toLowerCase().split('+').map(p=>p.trim());const modifiers=new Set();let key='';for(const part of parts){if(MODIFIER_KEYS[part]){modifiers.add(MODIFIER_KEYS[part]);}else{key=KEY_ALIASES[part]||part;}}
-return{modifiers,key};}
-function getShortcutId(event){const parts=[];if(event.ctrlKey)parts.push('ctrl');if(event.altKey)parts.push('alt');if(event.shiftKey)parts.push('shift');if(event.metaKey)parts.push('meta');let key=event.key.toLowerCase();if(key===' ')key='space';parts.push(key);return parts.join('+');}
-function shouldIgnore(event,options){if(!options.allowInInputs){const target=event.target;if(IGNORED_ELEMENTS.includes(target.tagName)){return true;}
-if(target.isContentEditable){return true;}}
-return false;}
-function handleKeydown(event){const id=getShortcutId(event);const shortcutData=shortcuts.get(id);if(!shortcutData)return;const{callback,options}=shortcutData;if(shouldIgnore(event,options))return;if(options.preventDefault){event.preventDefault();}
-if(options.stopPropagation){event.stopPropagation();}
-try{callback(event);}catch(error){console.error(`[KeyboardShortcuts] 执行快捷键 "${id}" 时出错:`,error);}}
-return{init:function(){if(initialized)return;document.addEventListener('keydown',handleKeydown);initialized=true;this.registerDefaults();console.log('[KeyboardShortcuts] 已初始化');},register:function(shortcut,callback,options={}){const defaultOptions={preventDefault:true,stopPropagation:false,allowInInputs:false};const mergedOptions={...defaultOptions,...options};const{modifiers,key}=parseShortcut(shortcut);const parts=[];if(modifiers.has('ctrlKey'))parts.push('ctrl');if(modifiers.has('altKey'))parts.push('alt');if(modifiers.has('shiftKey'))parts.push('shift');if(modifiers.has('metaKey'))parts.push('meta');parts.push(key.toLowerCase());const id=parts.join('+');if(shortcuts.has(id)){console.warn(`[KeyboardShortcuts] 快捷键 "${shortcut}" 已存在，将被覆盖`);}
-shortcuts.set(id,{callback,options:mergedOptions});console.debug(`[KeyboardShortcuts] 注册: ${id}`);},unregister:function(shortcut){const{modifiers,key}=parseShortcut(shortcut);const parts=[];if(modifiers.has('ctrlKey'))parts.push('ctrl');if(modifiers.has('altKey'))parts.push('alt');if(modifiers.has('shiftKey'))parts.push('shift');if(modifiers.has('metaKey'))parts.push('meta');parts.push(key.toLowerCase());const id=parts.join('+');if(shortcuts.delete(id)){console.debug(`[KeyboardShortcuts] 注销: ${id}`);}},registerDefaults:function(){this.register('escape',()=>{const settingsPanel=document.getElementById('settings-panel');if(settingsPanel&&settingsPanel.classList.contains('show')){settingsPanel.classList.remove('show');settingsPanel.classList.add('hidden');return;}
-const imageModal=document.getElementById('image-modal');if(imageModal&&imageModal.classList.contains('show')){imageModal.classList.remove('show');return;}});const submitShortcut=navigator.platform.includes('Mac')?'meta+enter':'ctrl+enter';this.register(submitShortcut,()=>{const submitBtn=document.getElementById('submit-btn');if(submitBtn&&!submitBtn.disabled){submitBtn.click();}},{allowInInputs:true});const helpShortcut=navigator.platform.includes('Mac')?'meta+/':'ctrl+/';this.register(helpShortcut,()=>{this.showHelp();});const settingsShortcut=navigator.platform.includes('Mac')?'meta+,':'ctrl+,';this.register(settingsShortcut,()=>{const settingsBtn=document.getElementById('settings-btn');if(settingsBtn)settingsBtn.click();});this.register('t',()=>{if(typeof ThemeManager!=='undefined'){ThemeManager.toggle();}});this.register('tab',(event)=>{const tabs=document.querySelectorAll('.task-tab:not(.hidden)');if(tabs.length>1){event.preventDefault();const currentIndex=Array.from(tabs).findIndex(tab=>tab.classList.contains('active'));const nextIndex=(currentIndex+1)%tabs.length;tabs[nextIndex].click();}});this.register('shift+tab',(event)=>{const tabs=document.querySelectorAll('.task-tab:not(.hidden)');if(tabs.length>1){event.preventDefault();const currentIndex=Array.from(tabs).findIndex(tab=>tab.classList.contains('active'));const prevIndex=(currentIndex-1+tabs.length)%tabs.length;tabs[prevIndex].click();}});},showHelp:function(){const isMac=navigator.platform.includes('Mac');const mod=isMac?'⌘':'Ctrl';const alt=isMac?'⌥':'Alt';const helpText=`
+/**
+ * ========================================================================
+ * AI Intervention Agent - 键盘快捷键模块 (Keyboard Shortcuts)
+ * ========================================================================
+ *
+ * 功能说明：
+ *   - 全局快捷键管理
+ *   - 可自定义快捷键映射
+ *   - 冲突检测和处理
+ *   - 上下文感知（不同页面区域使用不同快捷键）
+ *
+ * 使用方法：
+ *   KeyboardShortcuts.register('ctrl+s', () => save());
+ *   KeyboardShortcuts.unregister('ctrl+s');
+ *
+ * ========================================================================
+ */
+
+const KeyboardShortcuts = (function () {
+  'use strict';
+
+  // ========================================
+  // 常量和配置
+  // ========================================
+
+  // 修饰键映射
+  const MODIFIER_KEYS = {
+    ctrl: 'ctrlKey',
+    alt: 'altKey',
+    shift: 'shiftKey',
+    meta: 'metaKey',
+    cmd: 'metaKey',
+    command: 'metaKey',
+    option: 'altKey'
+  };
+
+  // 特殊键名映射
+  const KEY_ALIASES = {
+    'esc': 'Escape',
+    'escape': 'Escape',
+    'enter': 'Enter',
+    'return': 'Enter',
+    'space': ' ',
+    'spacebar': ' ',
+    'up': 'ArrowUp',
+    'down': 'ArrowDown',
+    'left': 'ArrowLeft',
+    'right': 'ArrowRight',
+    'delete': 'Delete',
+    'del': 'Delete',
+    'backspace': 'Backspace',
+    'tab': 'Tab',
+    'home': 'Home',
+    'end': 'End',
+    'pageup': 'PageUp',
+    'pagedown': 'PageDown'
+  };
+
+  // 默认忽略快捷键的元素类型
+  const IGNORED_ELEMENTS = ['INPUT', 'TEXTAREA', 'SELECT'];
+
+  // ========================================
+  // 内部状态
+  // ========================================
+
+  // 注册的快捷键 Map<string, { callback: Function, options: Object }>
+  const shortcuts = new Map();
+
+  // 是否已初始化
+  let initialized = false;
+
+  // ========================================
+  // 工具函数
+  // ========================================
+
+  /**
+   * 解析快捷键字符串
+   * @param {string} shortcut - 快捷键字符串 (如 "ctrl+shift+s")
+   * @returns {{ modifiers: Set, key: string }}
+   */
+  function parseShortcut(shortcut) {
+    const parts = shortcut.toLowerCase().split('+').map(p => p.trim());
+    const modifiers = new Set();
+    let key = '';
+
+    for (const part of parts) {
+      if (MODIFIER_KEYS[part]) {
+        modifiers.add(MODIFIER_KEYS[part]);
+      } else {
+        key = KEY_ALIASES[part] || part;
+      }
+    }
+
+    return { modifiers, key };
+  }
+
+  /**
+   * 生成标准化的快捷键 ID
+   * @param {KeyboardEvent} event - 键盘事件
+   * @returns {string}
+   */
+  function getShortcutId(event) {
+    const parts = [];
+
+    if (event.ctrlKey) parts.push('ctrl');
+    if (event.altKey) parts.push('alt');
+    if (event.shiftKey) parts.push('shift');
+    if (event.metaKey) parts.push('meta');
+
+    // 标准化键名
+    let key = event.key.toLowerCase();
+    if (key === ' ') key = 'space';
+    parts.push(key);
+
+    return parts.join('+');
+  }
+
+  /**
+   * 检查是否应该忽略快捷键
+   * @param {KeyboardEvent} event - 键盘事件
+   * @param {Object} options - 选项
+   * @returns {boolean}
+   */
+  function shouldIgnore(event, options) {
+    // 检查是否在忽略元素内
+    if (!options.allowInInputs) {
+      const target = event.target;
+      if (IGNORED_ELEMENTS.includes(target.tagName)) {
+        return true;
+      }
+      if (target.isContentEditable) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * 主键盘事件处理器
+   * @param {KeyboardEvent} event
+   */
+  function handleKeydown(event) {
+    const id = getShortcutId(event);
+    const shortcutData = shortcuts.get(id);
+
+    if (!shortcutData) return;
+
+    const { callback, options } = shortcutData;
+
+    // 检查是否应该忽略
+    if (shouldIgnore(event, options)) return;
+
+    // 阻止默认行为
+    if (options.preventDefault) {
+      event.preventDefault();
+    }
+
+    // 阻止事件冒泡
+    if (options.stopPropagation) {
+      event.stopPropagation();
+    }
+
+    // 执行回调
+    try {
+      callback(event);
+    } catch (error) {
+      console.error(`[KeyboardShortcuts] 执行快捷键 "${id}" 时出错:`, error);
+    }
+  }
+
+  // ========================================
+  // 公共 API
+  // ========================================
+
+  return {
+    /**
+     * 初始化快捷键系统
+     */
+    init: function () {
+      if (initialized) return;
+
+      document.addEventListener('keydown', handleKeydown);
+      initialized = true;
+
+      // 注册默认快捷键
+      this.registerDefaults();
+
+      console.log('[KeyboardShortcuts] 已初始化');
+    },
+
+    /**
+     * 注册快捷键
+     * @param {string} shortcut - 快捷键字符串 (如 "ctrl+s", "cmd+enter")
+     * @param {Function} callback - 回调函数
+     * @param {Object} [options] - 选项
+     * @param {boolean} [options.preventDefault=true] - 是否阻止默认行为
+     * @param {boolean} [options.stopPropagation=false] - 是否阻止事件冒泡
+     * @param {boolean} [options.allowInInputs=false] - 是否在输入框内生效
+     */
+    register: function (shortcut, callback, options = {}) {
+      const defaultOptions = {
+        preventDefault: true,
+        stopPropagation: false,
+        allowInInputs: false
+      };
+
+      const mergedOptions = { ...defaultOptions, ...options };
+      const { modifiers, key } = parseShortcut(shortcut);
+
+      // 生成标准化 ID
+      const parts = [];
+      if (modifiers.has('ctrlKey')) parts.push('ctrl');
+      if (modifiers.has('altKey')) parts.push('alt');
+      if (modifiers.has('shiftKey')) parts.push('shift');
+      if (modifiers.has('metaKey')) parts.push('meta');
+      parts.push(key.toLowerCase());
+
+      const id = parts.join('+');
+
+      if (shortcuts.has(id)) {
+        console.warn(`[KeyboardShortcuts] 快捷键 "${shortcut}" 已存在，将被覆盖`);
+      }
+
+      shortcuts.set(id, { callback, options: mergedOptions });
+      console.debug(`[KeyboardShortcuts] 注册: ${id}`);
+    },
+
+    /**
+     * 注销快捷键
+     * @param {string} shortcut - 快捷键字符串
+     */
+    unregister: function (shortcut) {
+      const { modifiers, key } = parseShortcut(shortcut);
+
+      const parts = [];
+      if (modifiers.has('ctrlKey')) parts.push('ctrl');
+      if (modifiers.has('altKey')) parts.push('alt');
+      if (modifiers.has('shiftKey')) parts.push('shift');
+      if (modifiers.has('metaKey')) parts.push('meta');
+      parts.push(key.toLowerCase());
+
+      const id = parts.join('+');
+
+      if (shortcuts.delete(id)) {
+        console.debug(`[KeyboardShortcuts] 注销: ${id}`);
+      }
+    },
+
+    /**
+     * 注册默认快捷键
+     */
+    registerDefaults: function () {
+      // Escape - 关闭模态框/设置面板
+      this.register('escape', () => {
+        // 关闭设置面板
+        const settingsPanel = document.getElementById('settings-panel');
+        if (settingsPanel && settingsPanel.classList.contains('show')) {
+          settingsPanel.classList.remove('show');
+          settingsPanel.classList.add('hidden');
+          return;
+        }
+
+        // 关闭图片模态框
+        const imageModal = document.getElementById('image-modal');
+        if (imageModal && imageModal.classList.contains('show')) {
+          imageModal.classList.remove('show');
+          return;
+        }
+      });
+
+      // Ctrl/Cmd + Enter - 提交
+      const submitShortcut = navigator.platform.includes('Mac') ? 'meta+enter' : 'ctrl+enter';
+      this.register(submitShortcut, () => {
+        const submitBtn = document.getElementById('submit-btn');
+        if (submitBtn && !submitBtn.disabled) {
+          submitBtn.click();
+        }
+      }, { allowInInputs: true });
+
+      // Ctrl/Cmd + / - 显示快捷键帮助
+      const helpShortcut = navigator.platform.includes('Mac') ? 'meta+/' : 'ctrl+/';
+      this.register(helpShortcut, () => {
+        this.showHelp();
+      });
+
+      // Ctrl/Cmd + , - 打开设置
+      const settingsShortcut = navigator.platform.includes('Mac') ? 'meta+,' : 'ctrl+,';
+      this.register(settingsShortcut, () => {
+        const settingsBtn = document.getElementById('settings-btn');
+        if (settingsBtn) settingsBtn.click();
+      });
+
+      // T - 切换主题
+      this.register('t', () => {
+        if (typeof ThemeManager !== 'undefined') {
+          ThemeManager.toggle();
+        }
+      });
+
+      // Tab - 在任务间切换
+      this.register('tab', (event) => {
+        const tabs = document.querySelectorAll('.task-tab:not(.hidden)');
+        if (tabs.length > 1) {
+          event.preventDefault();
+          const currentIndex = Array.from(tabs).findIndex(
+            tab => tab.classList.contains('active')
+          );
+          const nextIndex = (currentIndex + 1) % tabs.length;
+          tabs[nextIndex].click();
+        }
+      });
+
+      // Shift + Tab - 反向切换任务
+      this.register('shift+tab', (event) => {
+        const tabs = document.querySelectorAll('.task-tab:not(.hidden)');
+        if (tabs.length > 1) {
+          event.preventDefault();
+          const currentIndex = Array.from(tabs).findIndex(
+            tab => tab.classList.contains('active')
+          );
+          const prevIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+          tabs[prevIndex].click();
+        }
+      });
+    },
+
+    /**
+     * 显示快捷键帮助
+     */
+    showHelp: function () {
+      const isMac = navigator.platform.includes('Mac');
+      const mod = isMac ? '⌘' : 'Ctrl';
+      const alt = isMac ? '⌥' : 'Alt';
+
+      const helpText = `
 ╔══════════════════════════════════════╗
-║       ⌨️ 键盘快捷键帮助             ║
+║         键盘快捷键帮助             ║
 ╠══════════════════════════════════════╣
 ║  ${mod}+Enter    提交反馈              ║
 ║  ${mod}+,        打开设置              ║
@@ -21,4 +344,46 @@ const imageModal=document.getElementById('image-modal');if(imageModal&&imageModa
 ║  Shift+Tab     上一个任务            ║
 ║  Escape        关闭弹窗/面板         ║
 ╚══════════════════════════════════════╝
-      `.trim();console.log(helpText);if(typeof notificationManager!=='undefined'){notificationManager.sendNotification('⌨️ 快捷键',`${mod}+Enter 提交 | T 切换主题 | Esc 关闭弹窗`,{tag:'keyboard-help',requireInteraction:false});}},getAll:function(){return new Map(shortcuts);},destroy:function(){document.removeEventListener('keydown',handleKeydown);shortcuts.clear();initialized=false;console.log('[KeyboardShortcuts] 已销毁');}};})();document.addEventListener('DOMContentLoaded',()=>{KeyboardShortcuts.init();});if(typeof module!=='undefined'&&module.exports){module.exports=KeyboardShortcuts;}
+      `.trim();
+
+      console.log(helpText);
+
+      // 显示提示通知
+      if (typeof notificationManager !== 'undefined') {
+        notificationManager.sendNotification(
+          '快捷键',
+          `${mod}+Enter 提交 | T 切换主题 | Esc 关闭弹窗`,
+          { tag: 'keyboard-help', requireInteraction: false }
+        );
+      }
+    },
+
+    /**
+     * 获取所有注册的快捷键
+     * @returns {Map}
+     */
+    getAll: function () {
+      return new Map(shortcuts);
+    },
+
+    /**
+     * 销毁快捷键系统
+     */
+    destroy: function () {
+      document.removeEventListener('keydown', handleKeydown);
+      shortcuts.clear();
+      initialized = false;
+      console.log('[KeyboardShortcuts] 已销毁');
+    }
+  };
+})();
+
+// 页面加载完成后初始化
+document.addEventListener('DOMContentLoaded', () => {
+  KeyboardShortcuts.init();
+});
+
+// 导出
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = KeyboardShortcuts;
+}

--- a/static/js/mathjax-loader.js
+++ b/static/js/mathjax-loader.js
@@ -122,10 +122,10 @@ window.loadMathJaxIfNeeded = function (element, text) {
   script.src = '/static/js/tex-mml-chtml.js' // 本地托管的 MathJax 脚本
   script.onload = function () {
     window._mathJaxLoaded = true
-    console.log('✅ MathJax 加载完成')
+    console.log('MathJax 加载完成')
   }
   script.onerror = function () {
-    console.error('❌ MathJax 加载失败')
+    console.error('MathJax 加载失败')
     window._mathJaxLoading = false
   }
   document.head.appendChild(script)

--- a/static/js/mathjax-loader.min.js
+++ b/static/js/mathjax-loader.min.js
@@ -1,26 +1,132 @@
-window.MathJax={tex:{inlineMath:[['$','$'],['\\(','\\)']],displayMath:[['$$','$$'],['\\[','\\]']],processEscapes:true,processEnvironments:true,packages:{'[+]':['ams','newcommand','configmacros']},tags:'ams'},options:{skipHtmlTags:['script','noscript','style','textarea','pre','code'],ignoreHtmlClass:'tex2jax_ignore',processHtmlClass:'tex2jax_process'},startup:{ready:()=>{console.log('MathJax 已加载完成')
-MathJax.startup.defaultReady()
-if(window._mathJaxPendingElements){window._mathJaxPendingElements.forEach(el=>{MathJax.typesetPromise([el]).catch(err=>console.warn('MathJax 渲染失败:',err))})
-window._mathJaxPendingElements=[]}}}}
-window._mathJaxLoading=false
-window._mathJaxLoaded=false
-window._mathJaxPendingElements=[]
-window.hasMathContent=function(text){if(!text)return false
-const mathPatterns=[/\$[^$]+\$/,/\$\$[^$]+\$\$/,/\\\([^)]+\\\)/,/\\\[[^\]]+\\\]/]
-return mathPatterns.some(pattern=>pattern.test(text))}
-window.loadMathJaxIfNeeded=function(element,text){if(!window.hasMathContent(text)){return}
-if(window._mathJaxLoaded&&window.MathJax&&window.MathJax.typesetPromise){MathJax.typesetPromise([element]).catch(err=>console.warn('MathJax 渲染失败:',err))
-return}
-window._mathJaxPendingElements.push(element)
-if(window._mathJaxLoading){return}
-window._mathJaxLoading=true
-console.log('📐 检测到数学公式，开始加载 MathJax (1.17MB)...')
-const script=document.createElement('script')
-script.id='MathJax-script'
-script.async=true
-script.src='/static/js/tex-mml-chtml.js'
-script.onload=function(){window._mathJaxLoaded=true
-console.log('✅ MathJax 加载完成')}
-script.onerror=function(){console.error('❌ MathJax 加载失败')
-window._mathJaxLoading=false}
-document.head.appendChild(script)}
+/**
+ * MathJax 懒加载器
+ *
+ * 功能说明：
+ *   MathJax 库较大（约 1.17MB），为优化首屏加载性能，
+ *   仅在检测到数学公式时才动态加载该库。
+ *
+ * 支持的公式语法：
+ *   - 行内公式：$...$, \(...\)
+ *   - 块级公式：$$...$$, \[...\]
+ *
+ * 加载流程：
+ *   1. renderMarkdownContent 调用 loadMathJaxIfNeeded
+ *   2. 检测内容是否包含数学公式
+ *   3. 首次检测到时，动态创建 <script> 加载 tex-mml-chtml.js
+ *   4. 加载完成后，MathJax.startup.ready 回调渲染所有待处理元素
+ *
+ * 状态管理：
+ *   - _mathJaxLoading: 标记是否正在加载（防止重复加载）
+ *   - _mathJaxLoaded: 标记是否加载完成
+ *   - _mathJaxPendingElements: 存储加载期间需要渲染的元素队列
+ */
+
+// MathJax 配置（预设，实际脚本按需加载）
+window.MathJax = {
+  tex: {
+    inlineMath: [
+      ['$', '$'],
+      ['\\(', '\\)']
+    ],
+    displayMath: [
+      ['$$', '$$'],
+      ['\\[', '\\]']
+    ],
+    processEscapes: true,
+    processEnvironments: true,
+    packages: { '[+]': ['ams', 'newcommand', 'configmacros'] },
+    tags: 'ams'
+  },
+  options: {
+    skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
+    ignoreHtmlClass: 'tex2jax_ignore',
+    processHtmlClass: 'tex2jax_process'
+  },
+  startup: {
+    ready: () => {
+      console.log('MathJax 已加载完成')
+      MathJax.startup.defaultReady()
+      // 加载完成后渲染所有公式
+      if (window._mathJaxPendingElements) {
+        window._mathJaxPendingElements.forEach(el => {
+          MathJax.typesetPromise([el]).catch(err => console.warn('MathJax 渲染失败:', err))
+        })
+        window._mathJaxPendingElements = []
+      }
+    }
+  }
+}
+
+// MathJax 懒加载状态标记
+window._mathJaxLoading = false // 是否正在加载脚本
+window._mathJaxLoaded = false // 是否加载完成
+window._mathJaxPendingElements = [] // 待渲染的元素队列
+
+/**
+ * 检测内容是否包含数学公式
+ * @param {string} text - 要检测的文本内容
+ * @returns {boolean} 是否包含数学公式
+ */
+window.hasMathContent = function (text) {
+  if (!text) return false
+  // 检测 LaTeX 数学公式语法（四种常见格式）
+  const mathPatterns = [
+    /\$[^$]+\$/, // 行内公式：$E=mc^2$
+    /\$\$[^$]+\$\$/, // 块级公式：$$\int_0^\infty$$
+    /\\\([^)]+\\\)/, // 行内公式（LaTeX 风格）：\(E=mc^2\)
+    /\\\[[^\]]+\\\]/ // 块级公式（LaTeX 风格）：\[\int_0^\infty\]
+  ]
+  return mathPatterns.some(pattern => pattern.test(text))
+}
+
+/**
+ * 按需加载 MathJax 并渲染数学公式
+ *
+ * @param {HTMLElement} element - 包含数学内容的 DOM 元素
+ * @param {string} text - 元素的文本内容（用于公式检测）
+ *
+ * 执行逻辑：
+ *   1. 检测是否有数学内容 → 无则直接返回
+ *   2. 若 MathJax 已加载 → 直接调用 typesetPromise 渲染
+ *   3. 若正在加载中 → 将元素加入待渲染队列
+ *   4. 若未加载 → 触发脚本加载，完成后批量渲染队列中的元素
+ */
+window.loadMathJaxIfNeeded = function (element, text) {
+  // 检测是否有数学内容
+  if (!window.hasMathContent(text)) {
+    return // 无数学公式，不加载
+  }
+
+  // 已加载完成，直接渲染
+  if (window._mathJaxLoaded && window.MathJax && window.MathJax.typesetPromise) {
+    MathJax.typesetPromise([element]).catch(err => console.warn('MathJax 渲染失败:', err))
+    return
+  }
+
+  // 记录待渲染元素（脚本加载完成后批量处理）
+  window._mathJaxPendingElements.push(element)
+
+  // 正在加载中，等待完成即可
+  if (window._mathJaxLoading) {
+    return
+  }
+
+  // 开始加载 MathJax 脚本
+  window._mathJaxLoading = true
+  console.log('📐 检测到数学公式，开始加载 MathJax (1.17MB)...')
+
+  // 动态创建 <script> 元素加载 MathJax
+  const script = document.createElement('script')
+  script.id = 'MathJax-script'
+  script.async = true
+  script.src = '/static/js/tex-mml-chtml.js' // 本地托管的 MathJax 脚本
+  script.onload = function () {
+    window._mathJaxLoaded = true
+    console.log('MathJax 加载完成')
+  }
+  script.onerror = function () {
+    console.error('MathJax 加载失败')
+    window._mathJaxLoading = false
+  }
+  document.head.appendChild(script)
+}

--- a/static/js/multi_task.js
+++ b/static/js/multi_task.js
@@ -85,6 +85,9 @@ if (typeof window.pendingNewTaskCount === 'undefined') {
 if (typeof window.newTaskHintTimer === 'undefined') {
   window.newTaskHintTimer = null // 通知合并定时器
 }
+if (typeof window.hasLoadedTaskSnapshot === 'undefined') {
+  window.hasLoadedTaskSnapshot = false // 首次任务快照仅用于建立基线，不触发系统通知
+}
 // 【优化】服务器时间同步机制 - 解决切换标签页后倒计时不准的问题
 if (typeof window.serverTimeOffset === 'undefined') {
   window.serverTimeOffset = 0 // 服务器时间与本地时间的偏移量（秒）
@@ -108,6 +111,9 @@ var tasksPollingTimer = window.tasksPollingTimer
 var taskTextareaContents = window.taskTextareaContents
 var taskOptionsStates = window.taskOptionsStates
 var taskImages = window.taskImages
+var pendingNewTaskCount = window.pendingNewTaskCount
+var newTaskHintTimer = window.newTaskHintTimer
+var hasLoadedTaskSnapshot = window.hasLoadedTaskSnapshot
 var feedbackPrompts = window.feedbackPrompts
 
 /**
@@ -482,31 +488,36 @@ Object.defineProperty(window, 'isManualSwitching', {
 function updateTasksList(tasks) {
   const oldTaskIds = currentTasks.map(t => t.task_id)
   const newTaskIds = tasks.map(t => t.task_id)
+  const isInitialTaskSnapshot = !hasLoadedTaskSnapshot
 
   // 检测新任务
   const addedTasks = newTaskIds.filter(id => !oldTaskIds.includes(id))
   if (addedTasks.length > 0) {
-    console.log(`✨ 检测到 ${addedTasks.length} 个新任务`)
+    console.log(`检测到 ${addedTasks.length} 个新任务`)
 
-    // 如果当前有活动任务,使用合并机制显示视觉提示
-    // 避免短时间内频繁弹出多个通知
-    if (activeTaskId) {
-      // 累加待显示的新任务数量
-      pendingNewTaskCount += addedTasks.length
+    if (!isInitialTaskSnapshot) {
+      // 如果当前有活动任务，使用合并机制避免短时间内频繁弹出多个通知
+      if (activeTaskId) {
+        pendingNewTaskCount += addedTasks.length
+        window.pendingNewTaskCount = pendingNewTaskCount
 
-      // 清除之前的定时器（防抖）
-      if (newTaskHintTimer) {
-        clearTimeout(newTaskHintTimer)
-      }
-
-      // 延迟 500ms 显示，等待可能的后续新任务
-      newTaskHintTimer = setTimeout(() => {
-        if (pendingNewTaskCount > 0) {
-          showNewTaskVisualHint(pendingNewTaskCount)
-          pendingNewTaskCount = 0 // 重置计数
+        if (newTaskHintTimer) {
+          clearTimeout(newTaskHintTimer)
         }
-        newTaskHintTimer = null
-      }, 500)
+
+        newTaskHintTimer = setTimeout(() => {
+          if (pendingNewTaskCount > 0) {
+            showNewTaskNotification(pendingNewTaskCount)
+            pendingNewTaskCount = 0
+            window.pendingNewTaskCount = 0
+          }
+          newTaskHintTimer = null
+          window.newTaskHintTimer = null
+        }, 500)
+        window.newTaskHintTimer = newTaskHintTimer
+      } else {
+        showNewTaskNotification(addedTasks.length)
+      }
     }
 
     // 为所有新任务启动倒计时（包括pending任务）
@@ -527,13 +538,13 @@ function updateTasksList(tasks) {
   // 检测已删除的任务并清理倒计时
   const removedTasks = oldTaskIds.filter(id => !newTaskIds.includes(id))
   if (removedTasks.length > 0) {
-    console.log(`🗑️ 检测到 ${removedTasks.length} 个已删除任务`)
+    console.log(`检测到 ${removedTasks.length} 个已删除任务`)
     removedTasks.forEach(taskId => {
       // 清理倒计时
       if (taskCountdowns[taskId]) {
         clearInterval(taskCountdowns[taskId].timer)
         delete taskCountdowns[taskId]
-        console.log(`✅ 已清理任务 ${taskId} 的倒计时`)
+        console.log(`已清理任务 ${taskId} 的倒计时`)
       }
       // 【优化】清理任务截止时间缓存，防止内存泄漏
       if (window.taskDeadlines[taskId] !== undefined) {
@@ -556,6 +567,8 @@ function updateTasksList(tasks) {
   const hasActiveTasks = tasks.length > 0 && tasks.some(t => t.status !== 'completed')
 
   currentTasks = tasks
+  hasLoadedTaskSnapshot = true
+  window.hasLoadedTaskSnapshot = true
 
   // 【热更新兜底】确保所有未完成任务都有倒计时
   // 场景：配置变更将 auto_resubmit_timeout 从 0（禁用）切回 >0（启用）
@@ -593,7 +606,7 @@ function updateTasksList(tasks) {
     updateCountdownRingColors(oldActiveTaskId, activeTaskId)
   } else if (!activeTaskId && tasks.length > 0) {
     // 如果activeTaskId为null，且有任务，自动设置第一个未完成任务为active
-    // ⚠️ 注意：tasks数组可能包含已完成任务，必须过滤
+    // 注意：tasks数组可能包含已完成任务，必须过滤
     const firstIncompleteTask = tasks.find(t => t.status !== 'completed')
     if (firstIncompleteTask) {
       activeTaskId = firstIncompleteTask.task_id
@@ -603,7 +616,7 @@ function updateTasksList(tasks) {
     }
   } else if (tasks.length === 0 && activeTaskId) {
     // 如果任务列表为空，重置activeTaskId
-    console.log(`✅ 任务列表已清空，重置 activeTaskId: ${activeTaskId} -> null`)
+    console.log(`任务列表已清空，重置 activeTaskId: ${activeTaskId} -> null`)
     activeTaskId = null
   }
 
@@ -616,7 +629,7 @@ function updateTasksList(tasks) {
 
   if (hasActiveTasks && isShowingNoContent) {
     // 有任务但显示的是无内容页面，切换到内容页面
-    console.log('🚀 有任务但显示无内容页面，切换到内容页面')
+    console.log('有任务但当前显示无内容页面，切换到内容页面')
     if (typeof showContentPage === 'function') {
       showContentPage()
     }
@@ -745,10 +758,10 @@ function renderTaskTabs() {
       const retryContainer = document.getElementById('task-tabs-container')
       const retryTabsContainer = document.getElementById('task-tabs')
       if (retryContainer && retryTabsContainer) {
-        console.log('✅ 重试成功，开始渲染标签栏')
+        console.log('重试成功，开始渲染标签栏')
         renderTaskTabs()
       } else {
-        console.error('❌ 重试失败，标签栏容器仍然未找到')
+        console.error('重试失败，标签栏容器仍然未找到')
       }
     }, 100)
     return
@@ -966,7 +979,7 @@ async function switchTask(taskId) {
     const textarea = document.getElementById('feedback-text')
     if (textarea) {
       taskTextareaContents[activeTaskId] = textarea.value
-      console.log(`✅ 已保存任务 ${activeTaskId} 的 textarea 内容`)
+      console.log(`已保存任务 ${activeTaskId} 的 textarea 内容`)
     }
 
     // 保存选项勾选状态
@@ -978,7 +991,7 @@ async function switchTask(taskId) {
         optionsStates[index] = checkbox.checked
       })
       taskOptionsStates[activeTaskId] = optionsStates
-      console.log(`✅ 已保存任务 ${activeTaskId} 的选项勾选状态`)
+      console.log(`已保存任务 ${activeTaskId} 的选项勾选状态`)
     }
 
     // 保存图片列表（深拷贝，避免引用问题）
@@ -987,7 +1000,7 @@ async function switchTask(taskId) {
       ...img
       // 保留所有字段，包括 blob URL（每个任务独立管理）
     }))
-    console.log(`✅ 已保存任务 ${activeTaskId} 的图片列表 (${selectedImages.length} 张)`)
+    console.log(`已保存任务 ${activeTaskId} 的图片列表 (${selectedImages.length} 张)`)
   }
 
   // 设置手动切换标志，防止轮询干扰
@@ -1004,10 +1017,10 @@ async function switchTask(taskId) {
   // 立即更新圆环颜色，不等待DOM重建
   updateCountdownRingColors(oldActiveTaskId, taskId)
 
-  // 🚀 立即从 currentTasks 获取任务信息并更新内容（不等待 API）
+  // 立即从 currentTasks 获取任务信息并更新内容（不等待 API）
   const cachedTask = currentTasks.find(t => t.task_id === taskId)
   if (cachedTask && cachedTask.prompt) {
-    console.log(`🚀 使用缓存任务信息立即更新内容: ${taskId}`)
+    console.log(`使用缓存任务信息立即更新内容: ${taskId}`)
 
     // 内联 updateTaskIdDisplay 逻辑（避免函数未定义错误）
     const taskIdContainer = document.getElementById('task-id-container')
@@ -1036,7 +1049,7 @@ async function switchTask(taskId) {
         if (!data.success) {
           console.error('激活任务失败:', data.error)
         } else {
-          console.log(`✅ 任务已激活: ${taskId}`)
+          console.log(`任务已激活: ${taskId}`)
         }
       })
       .catch(err => console.error('激活任务失败:', err))
@@ -1057,7 +1070,7 @@ async function switchTask(taskId) {
       manualSwitchingTimer = null
       // 分发事件通知其他模块恢复轮询
       window.dispatchEvent(new CustomEvent('taskSwitchComplete', { detail: { taskId } }))
-      console.log('✅ 任务切换锁定已解除，允许轮询恢复')
+      console.log('任务切换锁定已解除，允许轮询恢复')
     }, 200)
   }
 }
@@ -1148,7 +1161,7 @@ async function loadTaskDetails(taskId) {
 
     // 检查任务是否仍然是当前活动任务
     if (taskId !== activeTaskId) {
-      console.log(`⏭️ 跳过过期的任务详情: ${taskId}（当前活动: ${activeTaskId}）`)
+      console.log(`跳过过期的任务详情: ${taskId}（当前活动: ${activeTaskId}）`)
       return
     }
 
@@ -1175,7 +1188,7 @@ async function loadTaskDetails(taskId) {
       const textarea = document.getElementById('feedback-text')
       if (textarea && taskTextareaContents[taskId] !== undefined) {
         textarea.value = taskTextareaContents[taskId]
-        console.log(`✅ 已恢复任务 ${taskId} 的 textarea 内容`)
+        console.log(`已恢复任务 ${taskId} 的 textarea 内容`)
       }
       // 如果之前没有保存过内容，保持当前值（避免在用户正在输入时被轮询调用清空）
 
@@ -1193,7 +1206,7 @@ async function loadTaskDetails(taskId) {
           updateImageCounter()
           updateImagePreviewVisibility()
         }
-        console.log(`✅ 已恢复任务 ${taskId} 的图片列表 (${selectedImages.length} 张)`)
+        console.log(`已恢复任务 ${taskId} 的图片列表 (${selectedImages.length} 张)`)
       }
       // 如果之前没有保存过图片，保持当前值（避免在用户正在添加图片时被轮询调用清空）
 
@@ -1247,7 +1260,7 @@ async function updateDescriptionDisplay(prompt) {
   if (!descriptionElement) return
 
   try {
-    // 🚀 同步渲染（立即显示，不使用 requestAnimationFrame）
+    // 同步渲染（立即显示，不使用 requestAnimationFrame）
     let htmlContent = prompt
 
     // 使用 marked.js 解析 Markdown
@@ -1277,7 +1290,7 @@ async function updateDescriptionDisplay(prompt) {
       processStrikethrough(descriptionElement)
     }
 
-    console.log('✅ 同步渲染 Markdown 完成')
+    console.log('同步渲染 Markdown 完成')
 
     // MathJax 数学公式渲染（按需加载，不阻塞）
     // 注意：不能只在 MathJax 已加载时 typeset，否则“首次出现公式”的内容会一直不渲染
@@ -1339,7 +1352,7 @@ function updateOptionsDisplay(options) {
   let selectedStates = {}
   if (activeTaskId && taskOptionsStates[activeTaskId]) {
     selectedStates = taskOptionsStates[activeTaskId]
-    console.log(`✅ 已恢复任务 ${activeTaskId} 的选项勾选状态`)
+    console.log(`已恢复任务 ${activeTaskId} 的选项勾选状态`)
   } else {
     // 如果没有保存的状态，尝试保存当前状态（用于同一任务内的更新）
     const existingCheckboxes = optionsContainer.querySelectorAll('input[type="checkbox"]')
@@ -1444,15 +1457,15 @@ async function closeTask(taskId) {
     // 清除该任务保存的所有状态
     if (taskTextareaContents[taskId] !== undefined) {
       delete taskTextareaContents[taskId]
-      console.log(`✅ [关闭任务] 已清除任务 ${taskId} 保存的 textarea 内容`)
+      console.log(`[关闭任务] 已清除任务 ${taskId} 保存的 textarea 内容`)
     }
     if (taskOptionsStates[taskId] !== undefined) {
       delete taskOptionsStates[taskId]
-      console.log(`✅ [关闭任务] 已清除任务 ${taskId} 保存的选项勾选状态`)
+      console.log(`[关闭任务] 已清除任务 ${taskId} 保存的选项勾选状态`)
     }
     if (taskImages[taskId] !== undefined) {
       delete taskImages[taskId]
-      console.log(`✅ [关闭任务] 已清除任务 ${taskId} 保存的图片列表`)
+      console.log(`[关闭任务] 已清除任务 ${taskId} 保存的图片列表`)
     }
 
     // 从列表中移除
@@ -1744,15 +1757,15 @@ async function submitTaskFeedback(taskId, feedbackText, selectedOptions) {
       // 清除该任务保存的所有状态
       if (taskTextareaContents[taskId] !== undefined) {
         delete taskTextareaContents[taskId]
-        console.log(`✅ 已清除任务 ${taskId} 保存的 textarea 内容`)
+        console.log(`已清除任务 ${taskId} 保存的 textarea 内容`)
       }
       if (taskOptionsStates[taskId] !== undefined) {
         delete taskOptionsStates[taskId]
-        console.log(`✅ 已清除任务 ${taskId} 保存的选项勾选状态`)
+        console.log(`已清除任务 ${taskId} 保存的选项勾选状态`)
       }
       if (taskImages[taskId] !== undefined) {
         delete taskImages[taskId]
-        console.log(`✅ 已清除任务 ${taskId} 保存的图片列表`)
+        console.log(`已清除任务 ${taskId} 保存的图片列表`)
       }
 
       // 自动切换到下一个未完成的任务
@@ -1767,7 +1780,7 @@ async function submitTaskFeedback(taskId, feedbackText, selectedOptions) {
           console.log(`🔄 自动切换到下一个任务: ${nextTask.task_id}`)
           switchTask(nextTask.task_id)
         } else {
-          console.log(`✅ 所有任务已完成`)
+          console.log(`所有任务已完成`)
         }
       }, 300)
     } else {
@@ -1898,10 +1911,8 @@ function showNewTaskVisualHint(count) {
  * - 未来可能会移除
  */
 function showNewTaskNotification(count) {
-  // 使用新的视觉提示代替旧的通知
   showNewTaskVisualHint(count)
 
-  // 可选: 显示浏览器通知（如果有通知管理器）
   if (typeof notificationManager !== 'undefined') {
     notificationManager
       .sendNotification('AI Intervention Agent', `收到 ${count} 个新任务`, {
@@ -1963,7 +1974,7 @@ async function initMultiTaskSupport() {
       return
     }
     if (!tasksPollingTimer) {
-      console.warn('⚠️ 任务轮询已停止,自动重新启动')
+      console.warn('任务轮询已停止，自动重新启动')
       startTasksPolling()
     }
   }, 30000)
@@ -1977,7 +1988,7 @@ async function initMultiTaskSupport() {
         taskTextareaContents[activeTaskId] = textarea.value
       }
     })
-    console.log('✅ 已启用 textarea 实时保存')
+    console.log('已启用 textarea 实时保存')
   }
 
   // 监听选项变化
@@ -1994,7 +2005,7 @@ async function initMultiTaskSupport() {
         taskOptionsStates[activeTaskId] = states
       }
     })
-    console.log('✅ 已启用选项状态实时保存')
+    console.log('已启用选项状态实时保存')
   }
 
   console.log('多任务支持初始化完成 (包含轮询健康检查和实时保存)')

--- a/static/js/multi_task.min.js
+++ b/static/js/multi_task.min.js
@@ -1,194 +1,912 @@
-if(typeof window.currentTasks==='undefined'){window.currentTasks=[]}
-if(typeof window.activeTaskId==='undefined'){window.activeTaskId=null}
-if(typeof window.taskCountdowns==='undefined'){window.taskCountdowns={}}
-if(typeof window.tasksPollingTimer==='undefined'){window.tasksPollingTimer=null}
-if(typeof window.taskTextareaContents==='undefined'){window.taskTextareaContents={}}
-if(typeof window.taskOptionsStates==='undefined'){window.taskOptionsStates={}}
-if(typeof window.taskImages==='undefined'){window.taskImages={}}
-if(typeof window.pendingNewTaskCount==='undefined'){window.pendingNewTaskCount=0}
-if(typeof window.newTaskHintTimer==='undefined'){window.newTaskHintTimer=null}
-if(typeof window.serverTimeOffset==='undefined'){window.serverTimeOffset=0}
-if(typeof window.taskDeadlines==='undefined'){window.taskDeadlines={}}
-if(typeof window.feedbackPrompts==='undefined'){window.feedbackPrompts={resubmit_prompt:'请立即调用 interactive_feedback 工具',prompt_suffix:'\n请积极调用 interactive_feedback 工具'}}
-var currentTasks=window.currentTasks
-var activeTaskId=window.activeTaskId
-var taskCountdowns=window.taskCountdowns
-var tasksPollingTimer=window.tasksPollingTimer
-var taskTextareaContents=window.taskTextareaContents
-var taskOptionsStates=window.taskOptionsStates
-var taskImages=window.taskImages
-var feedbackPrompts=window.feedbackPrompts
-async function fetchFeedbackPromptsFresh(){try{const resp=await fetch('/api/get-feedback-prompts',{cache:'no-store'})
-if(!resp.ok)throw new Error(`HTTP ${resp.status}`)
-const data=await resp.json()
-if(data&&data.status==='success'&&data.config){window.feedbackPrompts=data.config
-feedbackPrompts=window.feedbackPrompts
-if(data.meta&&data.meta.config_file){const el=document.getElementById('config-file-path')
-if(el){el.value=data.meta.config_file}}
-return window.feedbackPrompts}}catch(e){console.warn('获取反馈提示语配置失败，使用本地默认值:',e)}
-return window.feedbackPrompts}
-if(typeof window.remainingSeconds==='undefined'){window.remainingSeconds=0}
-if(typeof window.countdownTimer==='undefined'){window.countdownTimer=null}
-var remainingSeconds=window.remainingSeconds
-var countdownTimer=window.countdownTimer
-if(typeof window.updateCountdownDisplay!=='function'){window.updateCountdownDisplay=function(seconds){const countdownContainer=document.getElementById('countdown-container')
-const countdownText=document.getElementById('countdown-text')
-if(!countdownContainer||!countdownText)return
-const displaySeconds=typeof seconds==='number'?seconds:window.remainingSeconds
-if(displaySeconds>0){countdownText.textContent=`${displaySeconds}秒后自动重新询问`
-countdownContainer.classList.remove('hidden')}else{countdownContainer.classList.add('hidden')}}}
-var updateCountdownDisplay=window.updateCountdownDisplay
-var TASKS_POLL_BASE_MS=2000
-var TASKS_POLL_MAX_MS=30000
-var tasksPollBackoffMs=TASKS_POLL_BASE_MS
-var tasksPollAbortController=null
-var tasksPollVisibilityHandlerInstalled=false
-function getNextBackoffMs(currentMs){const next=Math.min(TASKS_POLL_MAX_MS,Math.round(currentMs*1.7))
-const jitter=Math.round(next*0.1*Math.random())
-return next+jitter}
-async function fetchAndApplyTasks(reason){if(typeof document!=='undefined'&&document.hidden){return false}
-if(isManualSwitching){return false}
-try{if(tasksPollAbortController&&typeof tasksPollAbortController.abort==='function'){tasksPollAbortController.abort()}}catch(e){}
-if(typeof AbortController!=='undefined'){tasksPollAbortController=new AbortController()}else{tasksPollAbortController=null}
-const fetchOptions={cache:'no-store'}
-if(tasksPollAbortController){fetchOptions.signal=tasksPollAbortController.signal}
-try{const response=await fetch('/api/tasks',fetchOptions)
-if(!response.ok){throw new Error(`HTTP ${response.status}`)}
-const data=await response.json()
-if(data.success){if(data.server_time){const localTime=Date.now()/1000
-window.serverTimeOffset=data.server_time-localTime
-if(Math.abs(window.serverTimeOffset)>1){console.log(`服务器时间偏移: ${window.serverTimeOffset.toFixed(2)}s`)}}
-if(data.tasks){data.tasks.forEach(task=>{if(task.deadline){window.taskDeadlines[task.task_id]=task.deadline}
-if(taskCountdowns&&taskCountdowns[task.task_id]&&task.status!=='completed'){if(typeof task.auto_resubmit_timeout==='number'){if(task.auto_resubmit_timeout<=0){try{if(taskCountdowns[task.task_id].timer){clearInterval(taskCountdowns[task.task_id].timer)}}catch(e){}
-delete taskCountdowns[task.task_id]
-delete window.taskDeadlines[task.task_id]}else{taskCountdowns[task.task_id].timeout=task.auto_resubmit_timeout}}
-if(typeof task.remaining_time==='number'&&taskCountdowns[task.task_id]){taskCountdowns[task.task_id].remaining=task.remaining_time}}})}
-updateTasksList(data.tasks)
-updateTasksStats(data.stats)
-if(reason){console.debug(`任务列表已更新: ${reason}`)}
-return true}
-return false}catch(error){if(error&&(error.name==='AbortError'||error.code===20)){return false}
-console.error('获取任务列表失败:',error)
-return false}finally{tasksPollAbortController=null}}
-function scheduleNextTasksPoll(delayMs){if(tasksPollingTimer){clearTimeout(tasksPollingTimer)
-tasksPollingTimer=null}
-tasksPollingTimer=setTimeout(async()=>{const ok=await fetchAndApplyTasks('poll')
-if(ok){tasksPollBackoffMs=TASKS_POLL_BASE_MS}else{tasksPollBackoffMs=getNextBackoffMs(tasksPollBackoffMs)}
-scheduleNextTasksPoll(tasksPollBackoffMs)},Math.max(0,delayMs))}
-function startTasksPolling(){if(typeof document!=='undefined'&&document.hidden){console.log('页面不可见，跳过启动任务轮询')
-return}
-stopTasksPolling()
-tasksPollBackoffMs=TASKS_POLL_BASE_MS
-scheduleNextTasksPoll(0)
-if(!tasksPollVisibilityHandlerInstalled&&typeof document!=='undefined'){tasksPollVisibilityHandlerInstalled=true
-document.addEventListener('visibilitychange',()=>{if(document.hidden){stopTasksPolling()}else{startTasksPolling()}})
-window.addEventListener('beforeunload',()=>{stopTasksPolling()})}
-console.log('任务列表轮询已启动（治理：不可见暂停/指数退避/AbortController）')}
-function stopTasksPolling(){if(tasksPollingTimer){clearTimeout(tasksPollingTimer)
-tasksPollingTimer=null
-console.log('任务列表轮询已停止')}
-try{if(tasksPollAbortController&&typeof tasksPollAbortController.abort==='function'){tasksPollAbortController.abort()}}catch(e){}finally{tasksPollAbortController=null}}
-let isManualSwitching=false
-let manualSwitchingTimer=null
-Object.defineProperty(window,'isManualSwitching',{get:()=>isManualSwitching,set:val=>{isManualSwitching=val},configurable:true})
-function updateTasksList(tasks){const oldTaskIds=currentTasks.map(t=>t.task_id)
-const newTaskIds=tasks.map(t=>t.task_id)
-const addedTasks=newTaskIds.filter(id=>!oldTaskIds.includes(id))
-if(addedTasks.length>0){console.log(`✨ 检测到 ${addedTasks.length} 个新任务`)
-if(activeTaskId){pendingNewTaskCount+=addedTasks.length
-if(newTaskHintTimer){clearTimeout(newTaskHintTimer)}
-newTaskHintTimer=setTimeout(()=>{if(pendingNewTaskCount>0){showNewTaskVisualHint(pendingNewTaskCount)
-pendingNewTaskCount=0}
-newTaskHintTimer=null},500)}
-tasks.filter(t=>addedTasks.includes(t.task_id)).forEach(task=>{if(task.status!=='completed'&&!taskCountdowns[task.task_id]){const timeout=task.remaining_time??task.auto_resubmit_timeout??250
-startTaskCountdown(task.task_id,timeout,task.auto_resubmit_timeout||250)
-console.log(`已为新任务启动倒计时: ${task.task_id}, 剩余 ${timeout}s`)}})}
-const removedTasks=oldTaskIds.filter(id=>!newTaskIds.includes(id))
-if(removedTasks.length>0){console.log(`🗑️ 检测到 ${removedTasks.length} 个已删除任务`)
-removedTasks.forEach(taskId=>{if(taskCountdowns[taskId]){clearInterval(taskCountdowns[taskId].timer)
-delete taskCountdowns[taskId]
-console.log(`✅ 已清理任务 ${taskId} 的倒计时`)}
-if(window.taskDeadlines[taskId]!==undefined){delete window.taskDeadlines[taskId]}
-if(taskTextareaContents[taskId]!==undefined){delete taskTextareaContents[taskId]}
-if(taskOptionsStates[taskId]!==undefined){delete taskOptionsStates[taskId]}
-if(taskImages[taskId]!==undefined){delete taskImages[taskId]}})}
-const hasActiveTasks=tasks.length>0&&tasks.some(t=>t.status!=='completed')
-currentTasks=tasks
-tasks.forEach(task=>{if(task.status==='completed')return
-const total=typeof task.auto_resubmit_timeout==='number'?task.auto_resubmit_timeout:250
-if(total<=0){if(taskCountdowns[task.task_id]){try{if(taskCountdowns[task.task_id].timer){clearInterval(taskCountdowns[task.task_id].timer)}}catch(e){}
-delete taskCountdowns[task.task_id]}
-return}
-if(!taskCountdowns[task.task_id]){const remaining=task.remaining_time??total
-startTaskCountdown(task.task_id,remaining,total)}})
-const activeTask=tasks.find(t=>t.status==='active')
-if(activeTask&&activeTask.task_id!==activeTaskId){const oldActiveTaskId=activeTaskId
-activeTaskId=activeTask.task_id
-console.log(`同步activeTaskId: ${oldActiveTaskId} -> ${activeTaskId}`)
-updateCountdownRingColors(oldActiveTaskId,activeTaskId)}else if(!activeTaskId&&tasks.length>0){const firstIncompleteTask=tasks.find(t=>t.status!=='completed')
-if(firstIncompleteTask){activeTaskId=firstIncompleteTask.task_id
-console.log(`自动设置第一个未完成任务为active: ${activeTaskId}`)}else{console.log('所有任务已完成，不设置activeTaskId')}}else if(tasks.length===0&&activeTaskId){console.log(`✅ 任务列表已清空，重置 activeTaskId: ${activeTaskId} -> null`)
-activeTaskId=null}
-const contentContainer=document.getElementById('content-container')
-const noContentContainer=document.getElementById('no-content-container')
-const isShowingNoContent=noContentContainer&&noContentContainer.style.display==='flex'
-if(hasActiveTasks&&isShowingNoContent){console.log('🚀 有任务但显示无内容页面，切换到内容页面')
-if(typeof showContentPage==='function'){showContentPage()}}else if(!hasActiveTasks&&contentContainer&&contentContainer.style.display==='block'){console.log('📭 无任务但显示内容页面，切换到无内容页面')
-if(typeof showNoContentPage==='function'){showNoContentPage()}}
-renderTaskTabs()
-if(isManualSwitching){return}
-if(activeTask&&activeTask.task_id===activeTaskId){loadTaskDetails(activeTaskId)}}
-function updateTasksStats(stats){return}
-function renderTaskTabs(){const tabsContainer=document.getElementById('task-tabs')
-const container=document.getElementById('task-tabs-container')
-if(!container||!tabsContainer){console.warn('标签栏容器未找到，可能DOM还未加载完成，将在100ms后重试')
-setTimeout(()=>{const retryContainer=document.getElementById('task-tabs-container')
-const retryTabsContainer=document.getElementById('task-tabs')
-if(retryContainer&&retryTabsContainer){console.log('✅ 重试成功，开始渲染标签栏')
-renderTaskTabs()}else{console.error('❌ 重试失败，标签栏容器仍然未找到')}},100)
-return}
-const incompleteTasks=currentTasks.filter(task=>task.status!=='completed')
-if(incompleteTasks.length===0){container.classList.add('hidden')
-return}
-container.classList.remove('hidden')
-const existingTabs=tabsContainer.querySelectorAll('.task-tab')
-const existingTaskIds=Array.from(existingTabs).map(tab=>tab.dataset.taskId)
-const currentTaskIds=currentTasks.map(t=>t.task_id)
-const incompleteTaskIds=incompleteTasks.map(t=>t.task_id)
-const needsRebuild=existingTaskIds.length!==incompleteTaskIds.length||existingTaskIds.some((id,i)=>id!==incompleteTaskIds[i])
-if(needsRebuild){tabsContainer.innerHTML=''
-incompleteTasks.forEach(task=>{const tab=createTaskTab(task)
-tabsContainer.appendChild(tab)})}else{existingTabs.forEach(tab=>{const taskId=tab.dataset.taskId
-const isActive=taskId===activeTaskId
-tab.classList.toggle('active',isActive)})}}
-function createTaskTab(task){const tab=document.createElement('div')
-tab.className='task-tab'
-if(task.status==='active'){tab.classList.add('active')}
-tab.dataset.taskId=task.task_id
-const textSpan=document.createElement('span')
-textSpan.className='task-tab-text'
-const taskParts=task.task_id.split('-')
-const lastPart=taskParts[taskParts.length-1]
-const prefixParts=taskParts.slice(0,-1).join('-')
-let displayName
-if(prefixParts.length>12){displayName=`${prefixParts.substring(0, 11)}... ${lastPart}`}else{displayName=`${prefixParts} ${lastPart}`}
-textSpan.textContent=displayName
-textSpan.title=task.task_id
-tab.appendChild(textSpan)
-if(task.status!=='completed'){const countdownRing=document.createElement('div')
-countdownRing.className='countdown-ring'
-countdownRing.id=`countdown-${task.task_id}`
-let remaining,total
-if(taskCountdowns[task.task_id]){remaining=taskCountdowns[task.task_id].remaining
-total=taskCountdowns[task.task_id].timeout||250}else{remaining=task.remaining_time??task.auto_resubmit_timeout??250
-total=task.auto_resubmit_timeout||250}
-const radius=9
-const circumference=2*Math.PI*radius
-const progress=remaining/total
-const offset=circumference*(1-progress)
-const isActive=task.task_id===activeTaskId
-const strokeColor=isActive?'rgba(255, 255, 255, 0.9)':'rgba(139, 92, 246, 0.9)'
-countdownRing.innerHTML=`
+/**
+ * 多任务管理模块
+ *
+ * 提供完整的多任务并发管理功能，支持任务的创建、切换、轮询、倒计时和关闭。
+ *
+ * ## 核心功能
+ *
+ * 1. **任务轮询**：定期从服务器获取任务列表和统计信息
+ * 2. **任务列表管理**：动态更新任务列表，检测新增/删除的任务
+ * 3. **标签页渲染**：渲染任务标签页UI，支持拖拽和视觉反馈
+ * 4. **任务切换**：支持手动切换活动任务，更新UI状态
+ * 5. **任务倒计时**：为每个任务独立管理倒计时，支持自动提交
+ * 6. **任务关闭**：支持关闭单个任务，清理相关资源
+ * 7. **视觉提示**：新任务通知、倒计时环、状态标记
+ *
+ * ## 状态管理
+ *
+ * - `currentTasks`: 当前所有任务列表
+ * - `activeTaskId`: 当前活动任务ID
+ * - `taskCountdowns`: 任务倒计时字典
+ * - `taskTextareaContents`: 任务输入框内容缓存
+ * - `taskOptionsStates`: 任务选项状态缓存
+ * - `taskImages`: 任务图片缓存
+ * - `isManualSwitching`: 手动切换标志（防止冲突）
+ *
+ * ## 轮询机制
+ *
+ * - 轮询间隔：2秒
+ * - 轮询端点：`/api/tasks`
+ * - 自动检测新增/删除的任务
+ * - 支持启动/停止轮询
+ *
+ * ## 并发控制
+ *
+ * - 使用 `isManualSwitching` 标志防止手动切换与轮询冲突
+ * - 使用 `manualSwitchingTimer` 管理切换标志的生命周期
+ * - 任务切换时清除旧的定时器，避免竞态条件
+ *
+ * ## 资源清理
+ *
+ * - 任务删除时自动清理倒计时
+ * - 任务关闭时清理输入缓存、选项状态、图片缓存
+ * - 页面卸载时停止轮询和倒计时
+ *
+ * ## 注意事项
+ *
+ * - 任务切换是异步操作，需要等待服务器响应
+ * - 倒计时是独立的，每个任务有自己的计时器
+ * - 手动切换期间会暂停轮询更新，避免UI闪烁
+ * - 新任务会自动启动倒计时（包括 pending 状态）
+ *
+ * ## 依赖关系
+ *
+ * - 依赖 `dom-security.js` 中的 `DOMSecurityHelper`
+ * - 全局变量已在此文件中定义（如未存在则创建）
+ */
+
+// ==================== 全局变量定义 ====================
+// 使用 window 对象确保变量在全局作用域中可用
+if (typeof window.currentTasks === 'undefined') {
+  window.currentTasks = [] // 所有任务列表
+}
+if (typeof window.activeTaskId === 'undefined') {
+  window.activeTaskId = null // 当前活动任务ID
+}
+if (typeof window.taskCountdowns === 'undefined') {
+  window.taskCountdowns = {} // 每个任务的独立倒计时
+}
+if (typeof window.tasksPollingTimer === 'undefined') {
+  window.tasksPollingTimer = null // 任务轮询定时器
+}
+if (typeof window.taskTextareaContents === 'undefined') {
+  window.taskTextareaContents = {} // 存储每个任务的 textarea 内容
+}
+if (typeof window.taskOptionsStates === 'undefined') {
+  window.taskOptionsStates = {} // 存储每个任务的选项勾选状态
+}
+if (typeof window.taskImages === 'undefined') {
+  window.taskImages = {} // 存储每个任务的图片列表
+}
+// 新任务通知合并机制 - 防止频繁弹出多个通知
+if (typeof window.pendingNewTaskCount === 'undefined') {
+  window.pendingNewTaskCount = 0 // 待显示的新任务数量
+}
+if (typeof window.newTaskHintTimer === 'undefined') {
+  window.newTaskHintTimer = null // 通知合并定时器
+}
+if (typeof window.hasLoadedTaskSnapshot === 'undefined') {
+  window.hasLoadedTaskSnapshot = false // 首次任务快照仅用于建立基线，不触发系统通知
+}
+// 【优化】服务器时间同步机制 - 解决切换标签页后倒计时不准的问题
+if (typeof window.serverTimeOffset === 'undefined') {
+  window.serverTimeOffset = 0 // 服务器时间与本地时间的偏移量（秒）
+}
+if (typeof window.taskDeadlines === 'undefined') {
+  window.taskDeadlines = {} // 存储每个任务的截止时间戳（服务器时间）
+}
+// feedback 提示语（从服务端配置热更新获取）
+if (typeof window.feedbackPrompts === 'undefined') {
+  window.feedbackPrompts = {
+    resubmit_prompt: '请立即调用 interactive_feedback 工具',
+    prompt_suffix: '\n请积极调用 interactive_feedback 工具'
+  }
+}
+
+// 创建本地引用以便在函数中使用
+var currentTasks = window.currentTasks
+var activeTaskId = window.activeTaskId
+var taskCountdowns = window.taskCountdowns
+var tasksPollingTimer = window.tasksPollingTimer
+var taskTextareaContents = window.taskTextareaContents
+var taskOptionsStates = window.taskOptionsStates
+var taskImages = window.taskImages
+var pendingNewTaskCount = window.pendingNewTaskCount
+var newTaskHintTimer = window.newTaskHintTimer
+var hasLoadedTaskSnapshot = window.hasLoadedTaskSnapshot
+var feedbackPrompts = window.feedbackPrompts
+
+/**
+ * 从服务端获取最新的反馈提示语配置（支持运行中热更新）
+ * - 使用 /api/get-feedback-prompts
+ * - 成功：更新 window.feedbackPrompts
+ * - 失败：保留本地默认值
+ */
+async function fetchFeedbackPromptsFresh() {
+  try {
+    const resp = await fetch('/api/get-feedback-prompts', { cache: 'no-store' })
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    const data = await resp.json()
+    if (data && data.status === 'success' && data.config) {
+      window.feedbackPrompts = data.config
+      feedbackPrompts = window.feedbackPrompts
+
+      // 同步“当前实际使用的配置文件路径”到设置面板（如果存在对应DOM）
+      if (data.meta && data.meta.config_file) {
+        const el = document.getElementById('config-file-path')
+        if (el) {
+          el.value = data.meta.config_file
+        }
+      }
+      return window.feedbackPrompts
+    }
+  } catch (e) {
+    console.warn('获取反馈提示语配置失败，使用本地默认值:', e)
+  }
+  return window.feedbackPrompts
+}
+
+// 倒计时相关全局变量
+if (typeof window.remainingSeconds === 'undefined') {
+  window.remainingSeconds = 0
+}
+if (typeof window.countdownTimer === 'undefined') {
+  window.countdownTimer = null
+}
+var remainingSeconds = window.remainingSeconds
+var countdownTimer = window.countdownTimer
+
+/**
+ * 更新倒计时显示（如果函数未定义则提供默认实现）
+ * @param {number} seconds - 剩余秒数（可选）
+ */
+if (typeof window.updateCountdownDisplay !== 'function') {
+  window.updateCountdownDisplay = function (seconds) {
+    const countdownContainer = document.getElementById('countdown-container')
+    const countdownText = document.getElementById('countdown-text')
+
+    if (!countdownContainer || !countdownText) return
+
+    const displaySeconds = typeof seconds === 'number' ? seconds : window.remainingSeconds
+
+    if (displaySeconds > 0) {
+      countdownText.textContent = `${displaySeconds}秒后自动重新询问`
+      countdownContainer.classList.remove('hidden')
+    } else {
+      countdownContainer.classList.add('hidden')
+    }
+  }
+}
+var updateCountdownDisplay = window.updateCountdownDisplay
+
+// ==================== 任务轮询 ====================
+
+// 【轮询治理】避免重叠请求/页面不可见浪费/错误风暴
+var TASKS_POLL_BASE_MS = 2000
+var TASKS_POLL_MAX_MS = 30000
+var tasksPollBackoffMs = TASKS_POLL_BASE_MS
+var tasksPollAbortController = null
+var tasksPollVisibilityHandlerInstalled = false
+
+function getNextBackoffMs(currentMs) {
+  // 指数退避 + 轻微抖动，避免多客户端同时打爆服务端
+  const next = Math.min(TASKS_POLL_MAX_MS, Math.round(currentMs * 1.7))
+  const jitter = Math.round(next * 0.1 * Math.random()) // 0-10%
+  return next + jitter
+}
+
+async function fetchAndApplyTasks(reason) {
+  // 页面不可见：不发请求（由 visibilitychange 负责 stop，但这里再兜底）
+  if (typeof document !== 'undefined' && document.hidden) {
+    return false
+  }
+
+  // 手动切换期间：尽量少扰动 UI（不主动拉取）
+  if (isManualSwitching) {
+    return false
+  }
+
+  // AbortController：保证同时最多 1 个 in-flight 的 /api/tasks 请求
+  try {
+    if (tasksPollAbortController && typeof tasksPollAbortController.abort === 'function') {
+      tasksPollAbortController.abort()
+    }
+  } catch (e) {
+    // ignore
+  }
+
+  if (typeof AbortController !== 'undefined') {
+    tasksPollAbortController = new AbortController()
+  } else {
+    tasksPollAbortController = null
+  }
+
+  const fetchOptions = {
+    cache: 'no-store'
+  }
+  if (tasksPollAbortController) {
+    fetchOptions.signal = tasksPollAbortController.signal
+  }
+
+  try {
+    const response = await fetch('/api/tasks', fetchOptions)
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`)
+    }
+    const data = await response.json()
+
+    if (data.success) {
+      // 【优化】更新服务器时间偏移量，解决切换标签页后倒计时不准的问题
+      if (data.server_time) {
+        const localTime = Date.now() / 1000
+        window.serverTimeOffset = data.server_time - localTime
+        // 仅在偏移量较大时记录日志（避免日志刷屏）
+        if (Math.abs(window.serverTimeOffset) > 1) {
+          console.log(`服务器时间偏移: ${window.serverTimeOffset.toFixed(2)}s`)
+        }
+      }
+
+      // 【优化】保存每个任务的 deadline
+      if (data.tasks) {
+        data.tasks.forEach(task => {
+          if (task.deadline) {
+            window.taskDeadlines[task.task_id] = task.deadline
+          }
+          // 【热更新】当后端同步更新 auto_resubmit_timeout 时，前端倒计时也要实时跟随
+          // - deadline 已在上面更新，remaining 计算会随之变化
+          // - 这里额外同步 total(timeout) 以保证圆环进度正确
+          if (taskCountdowns && taskCountdowns[task.task_id] && task.status !== 'completed') {
+            if (typeof task.auto_resubmit_timeout === 'number') {
+              // <=0 语义：禁用自动提交（清理倒计时）
+              if (task.auto_resubmit_timeout <= 0) {
+                try {
+                  if (taskCountdowns[task.task_id].timer) {
+                    clearInterval(taskCountdowns[task.task_id].timer)
+                  }
+                } catch (e) {
+                  // ignore
+                }
+                delete taskCountdowns[task.task_id]
+                delete window.taskDeadlines[task.task_id]
+              } else {
+                taskCountdowns[task.task_id].timeout = task.auto_resubmit_timeout
+              }
+            }
+            if (typeof task.remaining_time === 'number' && taskCountdowns[task.task_id]) {
+              taskCountdowns[task.task_id].remaining = task.remaining_time
+            }
+          }
+        })
+      }
+
+      updateTasksList(data.tasks)
+      updateTasksStats(data.stats)
+      if (reason) {
+        console.debug(`任务列表已更新: ${reason}`)
+      }
+      return true
+    }
+
+    return false
+  } catch (error) {
+    // AbortError：正常的“防重叠”路径，不计为错误
+    if (error && (error.name === 'AbortError' || error.code === 20)) {
+      return false
+    }
+    console.error('获取任务列表失败:', error)
+    return false
+  } finally {
+    // 释放 controller（避免长期持有）
+    tasksPollAbortController = null
+  }
+}
+
+function scheduleNextTasksPoll(delayMs) {
+  if (tasksPollingTimer) {
+    clearTimeout(tasksPollingTimer)
+    tasksPollingTimer = null
+  }
+  tasksPollingTimer = setTimeout(async () => {
+    const ok = await fetchAndApplyTasks('poll')
+    if (ok) {
+      tasksPollBackoffMs = TASKS_POLL_BASE_MS
+    } else {
+      tasksPollBackoffMs = getNextBackoffMs(tasksPollBackoffMs)
+    }
+    scheduleNextTasksPoll(tasksPollBackoffMs)
+  }, Math.max(0, delayMs))
+}
+
+/**
+ * 启动任务列表轮询
+ *
+ * 定期从服务器获取任务列表和统计信息，并更新UI。
+ *
+ * ## 功能说明
+ *
+ * - 清除已存在的轮询定时器（避免重复轮询）
+ * - 创建新的定时器，每2秒轮询一次
+ * - 请求 `/api/tasks` 端点获取任务数据
+ * - 成功时更新任务列表和统计信息
+ * - 失败时记录错误日志
+ *
+ * ## 轮询数据
+ *
+ * - `data.tasks`: 任务列表数组
+ * - `data.stats`: 统计信息对象
+ * - `data.success`: 请求是否成功
+ *
+ * ## 调用时机
+ *
+ * - 页面加载时自动调用
+ * - 用户手动刷新任务列表时
+ * - 任务切换完成后重新启动
+ *
+ * ## 注意事项
+ *
+ * - 轮询间隔不应过短（避免服务器压力）
+ * - 轮询失败不会中断定时器（继续尝试）
+ * - 页面卸载时应调用 `stopTasksPolling` 停止轮询
+ */
+function startTasksPolling() {
+  // 页面不可见时不启动轮询（恢复由 visibilitychange 触发）
+  if (typeof document !== 'undefined' && document.hidden) {
+    console.log('页面不可见，跳过启动任务轮询')
+    return
+  }
+
+  // 清理旧的定时器/中止旧请求
+  stopTasksPolling()
+
+  tasksPollBackoffMs = TASKS_POLL_BASE_MS
+  scheduleNextTasksPoll(0)
+
+  // 安装“页面可见性治理”（只安装一次）
+  if (!tasksPollVisibilityHandlerInstalled && typeof document !== 'undefined') {
+    tasksPollVisibilityHandlerInstalled = true
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        stopTasksPolling()
+      } else {
+        // 恢复时立即拉一次，减少“回到页面后空白/延迟”
+        startTasksPolling()
+      }
+    })
+    window.addEventListener('beforeunload', () => {
+      stopTasksPolling()
+    })
+  }
+
+  console.log('任务列表轮询已启动（治理：不可见暂停/指数退避/AbortController）')
+}
+
+/**
+ * 停止任务列表轮询
+ *
+ * 清除轮询定时器，停止定期获取任务列表。
+ *
+ * ## 功能说明
+ *
+ * - 检查定时器是否存在
+ * - 清除定时器并设置为 null
+ * - 输出停止日志
+ *
+ * ## 调用时机
+ *
+ * - 页面卸载时（防止内存泄漏）
+ * - 用户明确停止轮询时
+ * - 切换到单任务模式时
+ *
+ * ## 注意事项
+ *
+ * - 多次调用是安全的（会检查定时器是否存在）
+ * - 停止后需要手动调用 `startTasksPolling` 重新启动
+ */
+function stopTasksPolling() {
+  if (tasksPollingTimer) {
+    clearTimeout(tasksPollingTimer)
+    tasksPollingTimer = null
+    console.log('任务列表轮询已停止')
+  }
+
+  // 取消 in-flight 请求，避免页面切走/重启轮询时堆积
+  try {
+    if (tasksPollAbortController && typeof tasksPollAbortController.abort === 'function') {
+      tasksPollAbortController.abort()
+    }
+  } catch (e) {
+    // ignore
+  } finally {
+    tasksPollAbortController = null
+  }
+}
+
+// ==================== 任务列表更新 ====================
+
+// 防止轮询与手动切换冲突的标志
+// 同时暴露到 window 以便其他模块的内容轮询可以检查
+let isManualSwitching = false
+let manualSwitchingTimer = null
+
+// 将标志同步到 window 对象，供跨模块通信
+Object.defineProperty(window, 'isManualSwitching', {
+  get: () => isManualSwitching,
+  set: val => {
+    isManualSwitching = val
+  },
+  configurable: true
+})
+
+/**
+ * 更新任务列表
+ *
+ * 检测任务变化（新增/删除），更新任务列表，并渲染标签页。
+ *
+ * ## 功能说明
+ *
+ * 1. **检测新任务**
+ *    - 比较新旧任务ID列表
+ *    - 显示新任务数量提示
+ *    - 为新任务启动倒计时（包括 pending 状态）
+ *    - 显示视觉提示（如果当前有活动任务）
+ *
+ * 2. **检测已删除任务**
+ *    - 清理已删除任务的倒计时
+ *    - 清理输入框内容缓存
+ *    - 清理选项状态缓存
+ *    - 清理图片缓存
+ *    - 防止内存泄漏
+ *
+ * 3. **更新任务列表**
+ *    - 更新全局 `currentTasks` 变量
+ *    - 渲染任务标签页
+ *    - 输出日志记录
+ *
+ * @param {Array} tasks - 任务列表数组
+ *
+ * ## 任务对象结构
+ *
+ * - `task_id`: 任务唯一ID
+ * - `status`: 任务状态（pending/active/completed）
+ * - `prompt`: 任务提示信息
+ * - `predefined_options`: 预定义选项数组
+ * - `auto_resubmit_timeout`: 自动提交超时（秒）
+ *
+ * ## 并发控制
+ *
+ * - 使用 `isManualSwitching` 标志避免冲突
+ * - 手动切换期间不更新活动任务
+ * - 自动倒计时不会被手动切换打断
+ *
+ * ## 注意事项
+ *
+ * - 新任务会自动启动倒计时（包括 pending 状态）
+ * - 已删除任务的资源会立即清理
+ * - 更新操作是同步的（不会阻塞UI）
+ * - 倒计时是独立的，每个任务有自己的计时器
+ */
+function updateTasksList(tasks) {
+  const oldTaskIds = currentTasks.map(t => t.task_id)
+  const newTaskIds = tasks.map(t => t.task_id)
+  const isInitialTaskSnapshot = !hasLoadedTaskSnapshot
+
+  // 检测新任务
+  const addedTasks = newTaskIds.filter(id => !oldTaskIds.includes(id))
+  if (addedTasks.length > 0) {
+    console.log(`检测到 ${addedTasks.length} 个新任务`)
+
+    if (!isInitialTaskSnapshot) {
+      // 如果当前有活动任务，使用合并机制避免短时间内频繁弹出多个通知
+      if (activeTaskId) {
+        pendingNewTaskCount += addedTasks.length
+        window.pendingNewTaskCount = pendingNewTaskCount
+
+        if (newTaskHintTimer) {
+          clearTimeout(newTaskHintTimer)
+        }
+
+        newTaskHintTimer = setTimeout(() => {
+          if (pendingNewTaskCount > 0) {
+            showNewTaskNotification(pendingNewTaskCount)
+            pendingNewTaskCount = 0
+            window.pendingNewTaskCount = 0
+          }
+          newTaskHintTimer = null
+          window.newTaskHintTimer = null
+        }, 500)
+        window.newTaskHintTimer = newTaskHintTimer
+      } else {
+        showNewTaskNotification(addedTasks.length)
+      }
+    }
+
+    // 为所有新任务启动倒计时（包括pending任务）
+    // 使用服务器返回的 remaining_time（剩余时间），而非固定的 auto_resubmit_timeout
+    // 这样刷新页面后倒计时不会重置
+    tasks
+      .filter(t => addedTasks.includes(t.task_id))
+      .forEach(task => {
+        if (task.status !== 'completed' && !taskCountdowns[task.task_id]) {
+          // 优先使用 remaining_time（服务器计算的剩余时间），否则使用 auto_resubmit_timeout
+          const timeout = task.remaining_time ?? task.auto_resubmit_timeout ?? 250
+          startTaskCountdown(task.task_id, timeout, task.auto_resubmit_timeout || 250)
+          console.log(`已为新任务启动倒计时: ${task.task_id}, 剩余 ${timeout}s`)
+        }
+      })
+  }
+
+  // 检测已删除的任务并清理倒计时
+  const removedTasks = oldTaskIds.filter(id => !newTaskIds.includes(id))
+  if (removedTasks.length > 0) {
+    console.log(`检测到 ${removedTasks.length} 个已删除任务`)
+    removedTasks.forEach(taskId => {
+      // 清理倒计时
+      if (taskCountdowns[taskId]) {
+        clearInterval(taskCountdowns[taskId].timer)
+        delete taskCountdowns[taskId]
+        console.log(`已清理任务 ${taskId} 的倒计时`)
+      }
+      // 【优化】清理任务截止时间缓存，防止内存泄漏
+      if (window.taskDeadlines[taskId] !== undefined) {
+        delete window.taskDeadlines[taskId]
+      }
+      // 清理任务缓存
+      if (taskTextareaContents[taskId] !== undefined) {
+        delete taskTextareaContents[taskId]
+      }
+      if (taskOptionsStates[taskId] !== undefined) {
+        delete taskOptionsStates[taskId]
+      }
+      if (taskImages[taskId] !== undefined) {
+        delete taskImages[taskId]
+      }
+    })
+  }
+
+  // 检测当前页面状态和任务状态
+  const hasActiveTasks = tasks.length > 0 && tasks.some(t => t.status !== 'completed')
+
+  currentTasks = tasks
+  hasLoadedTaskSnapshot = true
+  window.hasLoadedTaskSnapshot = true
+
+  // 【热更新兜底】确保所有未完成任务都有倒计时
+  // 场景：配置变更将 auto_resubmit_timeout 从 0（禁用）切回 >0（启用）
+  tasks.forEach(task => {
+    if (task.status === 'completed') return
+    const total = typeof task.auto_resubmit_timeout === 'number' ? task.auto_resubmit_timeout : 250
+    if (total <= 0) {
+      // 禁用：确保不启动倒计时
+      if (taskCountdowns[task.task_id]) {
+        try {
+          if (taskCountdowns[task.task_id].timer) {
+            clearInterval(taskCountdowns[task.task_id].timer)
+          }
+        } catch (e) {
+          // ignore
+        }
+        delete taskCountdowns[task.task_id]
+      }
+      return
+    }
+    if (!taskCountdowns[task.task_id]) {
+      const remaining = task.remaining_time ?? total
+      startTaskCountdown(task.task_id, remaining, total)
+    }
+  })
+
+  // 从任务列表中找到active任务，同步activeTaskId
+  const activeTask = tasks.find(t => t.status === 'active')
+  if (activeTask && activeTask.task_id !== activeTaskId) {
+    const oldActiveTaskId = activeTaskId
+    activeTaskId = activeTask.task_id
+    console.log(`同步activeTaskId: ${oldActiveTaskId} -> ${activeTaskId}`)
+
+    // 更新圆环颜色
+    updateCountdownRingColors(oldActiveTaskId, activeTaskId)
+  } else if (!activeTaskId && tasks.length > 0) {
+    // 如果activeTaskId为null，且有任务，自动设置第一个未完成任务为active
+    // 注意：tasks数组可能包含已完成任务，必须过滤
+    const firstIncompleteTask = tasks.find(t => t.status !== 'completed')
+    if (firstIncompleteTask) {
+      activeTaskId = firstIncompleteTask.task_id
+      console.log(`自动设置第一个未完成任务为active: ${activeTaskId}`)
+    } else {
+      console.log('所有任务已完成，不设置activeTaskId')
+    }
+  } else if (tasks.length === 0 && activeTaskId) {
+    // 如果任务列表为空，重置activeTaskId
+    console.log(`任务列表已清空，重置 activeTaskId: ${activeTaskId} -> null`)
+    activeTaskId = null
+  }
+
+  // 确保页面状态与任务状态一致
+  // - 有未完成任务时，显示内容页面
+  // - 无未完成任务时，显示无内容页面
+  const contentContainer = document.getElementById('content-container')
+  const noContentContainer = document.getElementById('no-content-container')
+  const isShowingNoContent = noContentContainer && noContentContainer.style.display === 'flex'
+
+  if (hasActiveTasks && isShowingNoContent) {
+    // 有任务但显示的是无内容页面，切换到内容页面
+    console.log('有任务但当前显示无内容页面，切换到内容页面')
+    if (typeof showContentPage === 'function') {
+      showContentPage()
+    }
+  } else if (!hasActiveTasks && contentContainer && contentContainer.style.display === 'block') {
+    // 无任务但显示的是内容页面，切换到无内容页面
+    console.log('📭 无任务但显示内容页面，切换到无内容页面')
+    if (typeof showNoContentPage === 'function') {
+      showNoContentPage()
+    }
+  }
+
+  // 更新标签页UI
+  renderTaskTabs()
+
+  // 如果正在手动切换，跳过自动加载
+  if (isManualSwitching) {
+    return
+  }
+
+  // 如果activeTaskId刚刚被同步更新，加载其详情
+  // （activeTask已在上面定义，不重复声明）
+  if (activeTask && activeTask.task_id === activeTaskId) {
+    loadTaskDetails(activeTaskId)
+  }
+}
+
+/**
+ * 更新任务统计信息
+ *
+ * 保留的函数，用于向后兼容。任务计数徽章已从UI中移除。
+ *
+ * ## 功能说明
+ *
+ * - 此函数当前为空实现
+ * - 保留是为了避免破坏现有调用
+ * - 未来可能会移除或重新实现
+ *
+ * @param {Object} stats - 统计信息对象（未使用）
+ *
+ * ## 注意事项
+ *
+ * - 不执行任何操作
+ * - 可以安全调用
+ * - 不影响性能
+ */
+function updateTasksStats(stats) {
+  // 任务计数徽章已从UI中移除，此函数不再执行任何操作
+  // 保留此函数是为了避免其他代码调用时出错
+  return
+
+  /* 旧代码已注释（徽章功能已移除）
+  const badge = document.getElementById('task-count-badge')
+  if (!badge) {
+    console.warn('任务计数徽章元素未找到')
+    return
+  }
+  if (stats.pending > 0) {
+    badge.textContent = stats.pending
+    badge.classList.remove('hidden')
+  } else {
+    badge.classList.add('hidden')
+  }
+  */
+}
+
+// ==================== 标签页渲染 ====================
+
+/**
+ * 渲染任务标签页
+ *
+ * 动态渲染所有任务的标签页UI，支持增量更新，避免全量重渲染。
+ *
+ * ## 功能说明
+ *
+ * - 获取标签页容器元素
+ * - 构建已存在标签的ID映射
+ * - 遍历当前任务列表，创建/更新标签页
+ * - 删除不再存在的标签页
+ * - 使用 DocumentFragment 批量添加新标签（性能优化）
+ *
+ * ## 优化策略
+ *
+ * - **增量更新**：只更新变化的部分，不重新渲染整个列表
+ * - **DOM批量操作**：使用 DocumentFragment 减少重排
+ * - **标签复用**：保留已存在的标签，只更新内容
+ * - **删除清理**：移除不再需要的标签
+ *
+ * ## 渲染逻辑
+ *
+ * 1. 检查容器是否存在
+ * 2. 构建当前DOM中标签的映射
+ * 3. 遍历任务列表：
+ *    - 标签已存在：跳过（复用）
+ *    - 标签不存在：创建新标签并添加到 Fragment
+ * 4. 批量添加新标签到容器
+ * 5. 删除不再存在的标签
+ *
+ * ## 标签顺序
+ *
+ * - 按任务添加顺序排列
+ * - Active 任务会高亮显示
+ * - 新任务添加到末尾
+ *
+ * ## 性能考虑
+ *
+ * - 避免全量DOM重建（使用增量更新）
+ * - 使用 DocumentFragment 减少重排次数
+ * - 标签复用避免重复创建
+ * - 适合频繁更新的场景
+ *
+ * ## 注意事项
+ *
+ * - 容器不存在时会记录警告
+ * - 标签创建由 `createTaskTab` 函数完成
+ * - 删除标签时会触发过渡动画
+ */
+function renderTaskTabs() {
+  const tabsContainer = document.getElementById('task-tabs')
+  const container = document.getElementById('task-tabs-container')
+
+  // DOM未加载时延迟重试
+  if (!container || !tabsContainer) {
+    console.warn('标签栏容器未找到，可能DOM还未加载完成，将在100ms后重试')
+    // 延迟100ms后重试一次
+    setTimeout(() => {
+      const retryContainer = document.getElementById('task-tabs-container')
+      const retryTabsContainer = document.getElementById('task-tabs')
+      if (retryContainer && retryTabsContainer) {
+        console.log('重试成功，开始渲染标签栏')
+        renderTaskTabs()
+      } else {
+        console.error('重试失败，标签栏容器仍然未找到')
+      }
+    }, 100)
+    return
+  }
+
+  // 过滤出未完成的任务
+  const incompleteTasks = currentTasks.filter(task => task.status !== 'completed')
+
+  if (incompleteTasks.length === 0) {
+    container.classList.add('hidden')
+    return
+  }
+
+  container.classList.remove('hidden')
+
+  // 优化：只更新active状态，不重建DOM
+  const existingTabs = tabsContainer.querySelectorAll('.task-tab')
+  const existingTaskIds = Array.from(existingTabs).map(tab => tab.dataset.taskId)
+  const currentTaskIds = currentTasks.map(t => t.task_id)
+
+  // 只比较未完成的任务
+  const incompleteTaskIds = incompleteTasks.map(t => t.task_id)
+
+  // 检查是否需要重建（任务列表变化）
+  const needsRebuild =
+    existingTaskIds.length !== incompleteTaskIds.length ||
+    existingTaskIds.some((id, i) => id !== incompleteTaskIds[i])
+
+  if (needsRebuild) {
+    // 任务列表变化，完全重建
+    tabsContainer.innerHTML = ''
+    // 只显示未完成的任务（pending 和 active）
+    incompleteTasks.forEach(task => {
+      const tab = createTaskTab(task)
+      tabsContainer.appendChild(tab)
+    })
+  } else {
+    // 仅更新active状态（极快）
+    existingTabs.forEach(tab => {
+      const taskId = tab.dataset.taskId
+      const isActive = taskId === activeTaskId
+      tab.classList.toggle('active', isActive)
+    })
+  }
+}
+
+/**
+ * 创建单个任务标签
+ *
+ * 为指定任务创建标签页UI元素，包含任务ID、状态标记、倒计时环和关闭按钮。
+ *
+ * @param {Object} task - 任务对象
+ * @returns {HTMLElement} 标签页DOM元素
+ *
+ * ## 标签结构
+ *
+ * - 外层容器：task-tab类
+ * - 倒计时环：SVG圆环进度指示器
+ * - 任务ID文本：显示任务ID
+ * - 状态标记：active标记
+ * - 关闭按钮：点击关闭任务
+ *
+ * ## 状态类
+ *
+ * - `active`：当前活动任务
+ * - `data-task-id`：任务ID属性
+ *
+ * ## 事件处理
+ *
+ * - 点击标签：切换任务
+ * - 点击关闭按钮：关闭任务（阻止冒泡）
+ *
+ * ## 安全性
+ *
+ * - 使用 `DOMSecurityHelper.createElement` 创建元素
+ * - 使用 `DOMSecurityHelper.setTextContent` 设置文本
+ * - 防止XSS攻击
+ *
+ * ## 注意事项
+ *
+ * - 标签ID格式：`task-tab-{task_id}`
+ * - 关闭按钮ID格式：`close-btn-{task_id}`
+ * - 倒计时环ID格式：`countdown-ring-{task_id}`
+ */
+function createTaskTab(task) {
+  const tab = document.createElement('div')
+  tab.className = 'task-tab'
+  if (task.status === 'active') {
+    tab.classList.add('active')
+  }
+  tab.dataset.taskId = task.task_id
+
+  // 任务名称
+  const textSpan = document.createElement('span')
+  textSpan.className = 'task-tab-text'
+
+  // 智能显示：前缀截断 + 完整数字
+  // 例如: "ai-intervention-agent-2822" → "ai-interven... 2822"
+  const taskParts = task.task_id.split('-')
+  const lastPart = taskParts[taskParts.length - 1] // 最后的数字
+  const prefixParts = taskParts.slice(0, -1).join('-') // 前面部分
+
+  let displayName
+  if (prefixParts.length > 12) {
+    // 前缀过长，截断
+    displayName = `${prefixParts.substring(0, 11)}... ${lastPart}`
+  } else {
+    displayName = `${prefixParts} ${lastPart}`
+  }
+
+  textSpan.textContent = displayName
+  textSpan.title = task.task_id // 悬停显示完整ID
+
+  // 先添加文本（左边）
+  tab.appendChild(textSpan)
+
+  // SVG圆环倒计时（总是显示，在右边）
+  if (task.status !== 'completed') {
+    const countdownRing = document.createElement('div')
+    countdownRing.className = 'countdown-ring'
+    countdownRing.id = `countdown-${task.task_id}`
+
+    // 使用已有的倒计时数据或服务器返回的剩余时间
+    let remaining, total
+    if (taskCountdowns[task.task_id]) {
+      remaining = taskCountdowns[task.task_id].remaining
+      total = taskCountdowns[task.task_id].timeout || 250
+    } else {
+      // 倒计时还未启动，优先使用服务器返回的 remaining_time
+      // 这样刷新页面后圆环显示正确的剩余时间
+      remaining = task.remaining_time ?? task.auto_resubmit_timeout ?? 250
+      total = task.auto_resubmit_timeout || 250
+    }
+
+    // SVG圆环实现
+    const radius = 9 // 圆环半径
+    const circumference = 2 * Math.PI * radius // 圆周长
+    const progress = remaining / total // 进度（0-1）
+    const offset = circumference * (1 - progress) // dash-offset
+
+    // 使用activeTaskId判断是否active，而不是task.status
+    const isActive = task.task_id === activeTaskId
+    const strokeColor = isActive ? 'rgba(255, 255, 255, 0.9)' : 'rgba(139, 92, 246, 0.9)'
+
+    countdownRing.innerHTML = `
       <svg width="22" height="22" viewBox="0 0 22 22">
         <circle
           cx="11" cy="11" r="${radius}"
@@ -202,187 +920,938 @@ countdownRing.innerHTML=`
       </svg>
       <span class="countdown-number">${remaining}</span>
     `
-countdownRing.title=`剩余${remaining}秒`
-tab.appendChild(countdownRing)}
-tab.onclick=()=>switchTask(task.task_id)
-return tab}
-async function switchTask(taskId){if(activeTaskId){const textarea=document.getElementById('feedback-text')
-if(textarea){taskTextareaContents[activeTaskId]=textarea.value
-console.log(`✅ 已保存任务 ${activeTaskId} 的 textarea 内容`)}
-const optionsContainer=document.getElementById('options-container')
-if(optionsContainer){const checkboxes=optionsContainer.querySelectorAll('input[type="checkbox"]')
-const optionsStates=[]
-checkboxes.forEach((checkbox,index)=>{optionsStates[index]=checkbox.checked})
-taskOptionsStates[activeTaskId]=optionsStates
-console.log(`✅ 已保存任务 ${activeTaskId} 的选项勾选状态`)}
-taskImages[activeTaskId]=selectedImages.map(img=>({...img}))
-console.log(`✅ 已保存任务 ${activeTaskId} 的图片列表 (${selectedImages.length} 张)`)}
-isManualSwitching=true
-window.dispatchEvent(new CustomEvent('taskSwitchStart',{detail:{taskId}}))
-const oldActiveTaskId=activeTaskId
-activeTaskId=taskId
-renderTaskTabs()
-updateCountdownRingColors(oldActiveTaskId,taskId)
-const cachedTask=currentTasks.find(t=>t.task_id===taskId)
-if(cachedTask&&cachedTask.prompt){console.log(`🚀 使用缓存任务信息立即更新内容: ${taskId}`)
-const taskIdContainer=document.getElementById('task-id-container')
-const taskIdText=document.getElementById('task-id-text')
-if(taskIdContainer&&taskIdText){if(cachedTask.task_id&&cachedTask.task_id.trim()){taskIdText.textContent=cachedTask.task_id
-taskIdContainer.classList.remove('hidden')}else{taskIdContainer.classList.add('hidden')}}
-updateDescriptionDisplay(cachedTask.prompt)
-if(cachedTask.predefined_options){updateOptionsDisplay(cachedTask.predefined_options)}}
-try{fetch(`/api/tasks/${taskId}/activate`,{method:'POST'}).then(res=>res.json()).then(data=>{if(!data.success){console.error('激活任务失败:',data.error)}else{console.log(`✅ 任务已激活: ${taskId}`)}}).catch(err=>console.error('激活任务失败:',err))
-loadTaskDetails(taskId).catch(err=>{console.warn('加载任务详情失败，但UI已从缓存更新:',err)})}catch(error){console.error('切换任务失败:',error)}finally{if(manualSwitchingTimer){clearTimeout(manualSwitchingTimer)}
-manualSwitchingTimer=setTimeout(()=>{isManualSwitching=false
-manualSwitchingTimer=null
-window.dispatchEvent(new CustomEvent('taskSwitchComplete',{detail:{taskId}}))
-console.log('✅ 任务切换锁定已解除，允许轮询恢复')},200)}}
-function updateCountdownRingColors(oldActiveTaskId,newActiveTaskId){if(oldActiveTaskId){const oldRing=document.getElementById(`countdown-${oldActiveTaskId}`)
-if(oldRing){const oldCircle=oldRing.querySelector('circle')
-if(oldCircle){oldCircle.setAttribute('stroke','rgba(139, 92, 246, 0.9)')}}}
-if(newActiveTaskId){const newRing=document.getElementById(`countdown-${newActiveTaskId}`)
-if(newRing){const newCircle=newRing.querySelector('circle')
-if(newCircle){newCircle.setAttribute('stroke','rgba(255, 255, 255, 0.9)')}}}}
-async function loadTaskDetails(taskId){try{const response=await fetch(`/api/tasks/${taskId}`)
-const data=await response.json()
-if(taskId!==activeTaskId){console.log(`⏭️ 跳过过期的任务详情: ${taskId}（当前活动: ${activeTaskId}）`)
-return}
-if(data.success){const task=data.task
-const taskIdContainer=document.getElementById('task-id-container')
-const taskIdText=document.getElementById('task-id-text')
-if(taskIdContainer&&taskIdText){if(task.task_id&&task.task_id.trim()){taskIdText.textContent=task.task_id
-taskIdContainer.classList.remove('hidden')}else{taskIdContainer.classList.add('hidden')}}
-updateDescriptionDisplay(task.prompt)
-updateOptionsDisplay(task.predefined_options)
-const textarea=document.getElementById('feedback-text')
-if(textarea&&taskTextareaContents[taskId]!==undefined){textarea.value=taskTextareaContents[taskId]
-console.log(`✅ 已恢复任务 ${taskId} 的 textarea 内容`)}
-if(taskImages[taskId]&&taskImages[taskId].length>0){selectedImages=taskImages[taskId].map(img=>({...img}))
-const previewContainer=document.getElementById('image-previews')
-if(previewContainer){previewContainer.innerHTML=''
-selectedImages.forEach(imageItem=>{renderImagePreview(imageItem,false)})
-updateImageCounter()
-updateImagePreviewVisibility()}
-console.log(`✅ 已恢复任务 ${taskId} 的图片列表 (${selectedImages.length} 张)`)}
-if(!taskCountdowns[task.task_id]){const remaining=task.remaining_time??task.auto_resubmit_timeout
-const total=task.auto_resubmit_timeout
-startTaskCountdown(task.task_id,remaining,total)
-console.log(`首次启动倒计时: ${taskId}, 剩余 ${remaining}s / 总 ${total}s`)}else{console.log(`倒计时已存在，不重置: ${taskId}`)}
-console.log(`已加载任务详情: ${taskId}`)}else{console.error('加载任务详情失败:',data.error)}}catch(error){console.error('加载任务详情失败:',error)}}
-async function updateDescriptionDisplay(prompt){const descriptionElement=document.getElementById('description')
-if(!descriptionElement)return
-try{let htmlContent=prompt
-if(typeof marked!=='undefined'){try{htmlContent=marked.parse(prompt)}catch(e){console.warn('marked.js 解析失败:',e)}}
-descriptionElement.innerHTML=htmlContent
-if(typeof Prism!=='undefined'){Prism.highlightAllUnder(descriptionElement)}
-if(typeof processCodeBlocks==='function'){processCodeBlocks(descriptionElement)}
-if(typeof processStrikethrough==='function'){processStrikethrough(descriptionElement)}
-console.log('✅ 同步渲染 Markdown 完成')
-const textContent=descriptionElement.textContent||''
-if(window.loadMathJaxIfNeeded){window.loadMathJaxIfNeeded(descriptionElement,textContent)}else if(window.MathJax&&window.MathJax.typesetPromise){window.MathJax.typesetPromise([descriptionElement]).catch(err=>{console.warn('MathJax 渲染失败:',err)})}}catch(error){console.error('更新描述失败:',error)
-descriptionElement.textContent=prompt}}
-function updateOptionsDisplay(options){const optionsContainer=document.getElementById('options-container')
-if(!optionsContainer)return
-let selectedStates={}
-if(activeTaskId&&taskOptionsStates[activeTaskId]){selectedStates=taskOptionsStates[activeTaskId]
-console.log(`✅ 已恢复任务 ${activeTaskId} 的选项勾选状态`)}else{const existingCheckboxes=optionsContainer.querySelectorAll('input[type="checkbox"]')
-existingCheckboxes.forEach(checkbox=>{selectedStates[checkbox.id]=checkbox.checked})}
-optionsContainer.innerHTML=''
-if(options&&options.length>0){options.forEach((option,index)=>{const optionDiv=document.createElement('div')
-optionDiv.className='option-item'
-const checkbox=document.createElement('input')
-checkbox.type='checkbox'
-checkbox.id=`option-${index}`
-checkbox.value=option
-const checkboxId=`option-${index}`
-if(selectedStates[checkboxId]||selectedStates[index]){checkbox.checked=true}
-const label=document.createElement('label')
-label.htmlFor=`option-${index}`
-label.textContent=option
-optionDiv.appendChild(checkbox)
-optionDiv.appendChild(label)
-optionsContainer.appendChild(optionDiv)})
-optionsContainer.classList.remove('hidden')
-optionsContainer.classList.add('visible')
-const separator=document.getElementById('separator')
-if(separator){separator.classList.remove('hidden')
-separator.classList.add('visible')}}else{optionsContainer.classList.add('hidden')
-optionsContainer.classList.remove('visible')}}
-async function closeTask(taskId){if(!confirm(`确定要关闭任务 ${taskId} 吗？`)){return}
-try{if(taskCountdowns[taskId]){clearInterval(taskCountdowns[taskId].timer)
-delete taskCountdowns[taskId]}
-if(taskTextareaContents[taskId]!==undefined){delete taskTextareaContents[taskId]
-console.log(`✅ [关闭任务] 已清除任务 ${taskId} 保存的 textarea 内容`)}
-if(taskOptionsStates[taskId]!==undefined){delete taskOptionsStates[taskId]
-console.log(`✅ [关闭任务] 已清除任务 ${taskId} 保存的选项勾选状态`)}
-if(taskImages[taskId]!==undefined){delete taskImages[taskId]
-console.log(`✅ [关闭任务] 已清除任务 ${taskId} 保存的图片列表`)}
-currentTasks=currentTasks.filter(t=>t.task_id!==taskId)
-renderTaskTabs()
-if(activeTaskId===taskId&&currentTasks.length>0){switchTask(currentTasks[0].task_id)}
-console.log(`已关闭任务: ${taskId}`)}catch(error){console.error('关闭任务失败:',error)}}
-function startTaskCountdown(taskId,remaining,total=null){const timeout=total||remaining
-if(taskCountdowns[taskId]&&taskCountdowns[taskId].timer){clearInterval(taskCountdowns[taskId].timer)}
-taskCountdowns[taskId]={remaining:remaining,timeout:timeout,timer:null}
-if(taskId===activeTaskId){updateCountdownDisplay(remaining)}
-function calculateRemainingFromDeadline(){const deadline=window.taskDeadlines[taskId]
-if(deadline){const adjustedNow=Date.now()/1000+(window.serverTimeOffset||0)
-return Math.max(0,Math.floor(deadline-adjustedNow))}
-return taskCountdowns[taskId].remaining-1}
-taskCountdowns[taskId].timer=setInterval(()=>{const newRemaining=calculateRemainingFromDeadline()
-taskCountdowns[taskId].remaining=newRemaining
-const countdownRing=document.getElementById(`countdown-${taskId}`)
-if(countdownRing){const remaining=taskCountdowns[taskId].remaining
-const total=taskCountdowns[taskId].timeout||250
-const progress=remaining/total
-const radius=9
-const circumference=2*Math.PI*radius
-const offset=circumference*(1-progress)
-const circle=countdownRing.querySelector('circle')
-const numberSpan=countdownRing.querySelector('.countdown-number')
-if(circle){circle.setAttribute('stroke-dashoffset',offset)}
-if(numberSpan){numberSpan.textContent=remaining}
-countdownRing.title=`剩余${remaining}秒`}
-if(taskId===activeTaskId){updateCountdownDisplay(taskCountdowns[taskId].remaining)}
-if(taskCountdowns[taskId].remaining<=0){clearInterval(taskCountdowns[taskId].timer)
-if(taskId===activeTaskId){autoSubmitTask(taskId)}else{if(!activeTaskId){console.log(`非激活任务 ${taskId} 超时，且无活动任务，自动提交`)
-autoSubmitTask(taskId)}else{console.log(`任务 ${taskId} 超时，但用户正在处理其他任务 ${activeTaskId}，暂不自动提交`)}}}},1000)
-console.log(`已启动任务倒计时: ${taskId}, 剩余 ${remaining}s / 总 ${timeout}s`)}
-function formatCountdown(seconds){if(seconds>60){return`${Math.floor(seconds / 60)}m`}
-return`${seconds}s`}
-async function autoSubmitTask(taskId){console.log(`任务 ${taskId} 倒计时结束，自动提交`)
-const prompts=await fetchFeedbackPromptsFresh()
-const defaultMessage=prompts&&prompts.resubmit_prompt?prompts.resubmit_prompt:'请立即调用 interactive_feedback 工具'
-await submitTaskFeedback(taskId,defaultMessage,[])}
-async function submitTaskFeedback(taskId,feedbackText,selectedOptions){try{const formData=new FormData()
-formData.append('feedback_text',feedbackText)
-formData.append('selected_options',JSON.stringify(selectedOptions))
-selectedImages.forEach((img,index)=>{if(img.file){formData.append(`image_${index}`,img.file)}})
-const response=await fetch(`/api/tasks/${taskId}/submit`,{method:'POST',body:formData})
-const data=await response.json()
-if(data.success){console.log(`任务 ${taskId} 提交成功`)
-if(taskCountdowns[taskId]){clearInterval(taskCountdowns[taskId].timer)
-delete taskCountdowns[taskId]}
-if(taskTextareaContents[taskId]!==undefined){delete taskTextareaContents[taskId]
-console.log(`✅ 已清除任务 ${taskId} 保存的 textarea 内容`)}
-if(taskOptionsStates[taskId]!==undefined){delete taskOptionsStates[taskId]
-console.log(`✅ 已清除任务 ${taskId} 保存的选项勾选状态`)}
-if(taskImages[taskId]!==undefined){delete taskImages[taskId]
-console.log(`✅ 已清除任务 ${taskId} 保存的图片列表`)}
-setTimeout(async()=>{await refreshTasksList()
-const nextTask=currentTasks.find(t=>t.task_id!==taskId&&t.status!=='completed')
-if(nextTask){console.log(`🔄 自动切换到下一个任务: ${nextTask.task_id}`)
-switchTask(nextTask.task_id)}else{console.log(`✅ 所有任务已完成`)}},300)}else{console.error('提交任务失败:',data.error)}}catch(error){console.error('提交任务反馈失败:',error)}}
-function showNewTaskVisualHint(count){const container=document.getElementById('task-tabs-container')
-if(!container)return
-const html=document.documentElement
-const currentTheme=html.getAttribute('data-theme')
-const isLightTheme=currentTheme==='light'
-const createSvg=`<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 20 20" fill="none" style="flex-shrink: 0; margin-right: 10px;"><path d="M15.5117 1.99707C15.9213 2.0091 16.3438 2.13396 16.6768 2.46679C17.0278 2.81814 17.1209 3.26428 17.0801 3.68261C17.0404 4.08745 16.8765 4.49344 16.6787 4.85058C16.3934 5.36546 15.9941 5.85569 15.6348 6.20898C15.7682 6.41421 15.8912 6.66414 15.9551 6.9453C16.0804 7.4977 15.9714 8.13389 15.4043 8.70116C14.8566 9.24884 13.974 9.54823 13.1943 9.71679C12.7628 9.81003 12.3303 9.86698 11.9473 9.90233C12.0596 10.2558 12.0902 10.7051 11.8779 11.2012L11.8223 11.3203C11.5396 11.8854 11.0275 12.2035 10.4785 12.3965C9.93492 12.5875 9.29028 12.6792 8.65332 12.75C7.99579 12.8231 7.34376 12.8744 6.70117 12.9775C6.14371 13.067 5.63021 13.1903 5.18652 13.3818L5.00585 13.4658C4.53515 14.2245 4.13745 14.9658 3.80957 15.6465C4.43885 15.2764 5.1935 15 5.99999 15C6.27614 15 6.49999 15.2238 6.49999 15.5C6.49999 15.7761 6.27613 16 5.99999 16C5.35538 16 4.71132 16.2477 4.15039 16.6103C3.58861 16.9736 3.14957 17.427 2.91601 17.7773C2.91191 17.7835 2.90568 17.788 2.90136 17.7939C2.88821 17.8119 2.8746 17.8289 2.85937 17.8447C2.85117 17.8533 2.84268 17.8612 2.83398 17.8691C2.81803 17.8835 2.80174 17.897 2.78417 17.9092C2.774 17.9162 2.76353 17.9225 2.75292 17.9287C2.73854 17.9372 2.72412 17.9451 2.70898 17.9521C2.69079 17.9605 2.6723 17.9675 2.65332 17.9736C2.6417 17.9774 2.63005 17.9805 2.61816 17.9834C2.60263 17.9872 2.5871 17.9899 2.57128 17.9922C2.55312 17.9948 2.53511 17.9974 2.5166 17.998C2.50387 17.9985 2.49127 17.9976 2.47851 17.9971C2.45899 17.9962 2.43952 17.9954 2.41992 17.9922C2.40511 17.9898 2.39062 17.9862 2.37597 17.9824C2.36477 17.9795 2.35294 17.9783 2.34179 17.9746C2.33697 17.973 2.33286 17.9695 2.32812 17.9678C2.31042 17.9612 2.29351 17.953 2.27636 17.9443C2.26332 17.9378 2.25053 17.9314 2.23828 17.9238C2.23339 17.9208 2.22747 17.9192 2.22265 17.916C2.21414 17.9103 2.20726 17.9026 2.19921 17.8965C2.18396 17.8849 2.16896 17.8735 2.15527 17.8603C2.14518 17.8507 2.13609 17.8404 2.12695 17.8301C2.11463 17.8161 2.10244 17.8023 2.09179 17.7871C2.08368 17.7756 2.07736 17.7631 2.07031 17.751C2.06168 17.7362 2.05297 17.7216 2.04589 17.706C2.03868 17.6901 2.03283 17.6738 2.02734 17.6572C2.0228 17.6436 2.01801 17.6302 2.01464 17.6162C2.01117 17.6017 2.009 17.587 2.00683 17.5722C2.00411 17.5538 2.00161 17.5354 2.00097 17.5166C2.00054 17.5039 2.00141 17.4912 2.00195 17.4785C2.00279 17.459 2.00364 17.4395 2.00683 17.4199C2.00902 17.4064 2.01327 17.3933 2.0166 17.3799C2.01973 17.3673 2.02123 17.3543 2.02539 17.3418C2.41772 16.1648 3.18163 14.466 4.30468 12.7012C4.31908 12.5557 4.34007 12.3582 4.36914 12.1201C4.43379 11.5907 4.53836 10.8564 4.69921 10.0381C5.0174 8.41955 5.56814 6.39783 6.50585 4.9912L6.73242 4.66894C7.27701 3.93277 7.93079 3.30953 8.61035 2.85156C9.3797 2.33311 10.2221 2 11.001 2C11.7951 2.00025 12.3531 2.35795 12.7012 2.70605C12.7723 2.77723 12.8348 2.84998 12.8896 2.91796C13.2829 2.66884 13.7917 2.39502 14.3174 2.21191C14.6946 2.08056 15.1094 1.98537 15.5117 1.99707ZM17.04 15.5537C17.1486 15.3 17.4425 15.1818 17.6963 15.29C17.95 15.3986 18.0683 15.6925 17.96 15.9463C17.4827 17.0612 16.692 18 15.5 18C14.6309 17.9999 13.9764 17.5003 13.5 16.7978C13.0236 17.5003 12.3691 18 11.5 18C10.6309 17.9999 9.97639 17.5003 9.49999 16.7978C9.02359 17.5003 8.36911 18 7.49999 18C7.22391 17.9999 7 17.7761 6.99999 17.5C6.99999 17.2239 7.22391 17 7.49999 17C8.07039 17 8.6095 16.5593 9.04003 15.5537L9.07421 15.4873C9.16428 15.3412 9.32494 15.25 9.49999 15.25C9.70008 15.25 9.88121 15.3698 9.95996 15.5537L10.042 15.7353C10.4581 16.6125 10.9652 16.9999 11.5 17C12.0704 17 12.6095 16.5593 13.04 15.5537L13.0742 15.4873C13.1643 15.3412 13.3249 15.25 13.5 15.25C13.7001 15.25 13.8812 15.3698 13.96 15.5537L14.042 15.7353C14.4581 16.6125 14.9652 16.9999 15.5 17C16.0704 17 16.6095 16.5593 17.04 15.5537ZM15.4824 2.99707C15.247 2.99022 14.9608 3.04682 14.6465 3.15624C14.0173 3.37541 13.389 3.76516 13.0498 4.01953C12.9277 4.11112 12.7697 4.14131 12.6221 4.10253C12.4745 4.06357 12.3522 3.9591 12.291 3.81933V3.81835C12.2892 3.81468 12.2861 3.80833 12.2822 3.80078C12.272 3.78092 12.2541 3.7485 12.2295 3.70898C12.1794 3.62874 12.1011 3.52019 11.9941 3.41308C11.7831 3.2021 11.4662 3.00024 11.001 2.99999C10.4904 2.99999 9.84173 3.22729 9.16894 3.68066C8.58685 4.07297 8.01568 4.61599 7.5371 5.26269L7.33789 5.54589C6.51634 6.77827 5.99475 8.63369 5.68066 10.2314C5.63363 10.4707 5.5913 10.7025 5.55371 10.9238C7.03031 9.01824 8.94157 7.19047 11.2812 6.05077C11.5295 5.92989 11.8283 6.03301 11.9492 6.28124C12.0701 6.52949 11.967 6.82829 11.7187 6.94921C9.33153 8.11208 7.38648 10.0746 5.91406 12.1103C6.12313 12.0632 6.33385 12.0238 6.54296 11.9902C7.21709 11.8821 7.92723 11.8243 8.54296 11.7558C9.17886 11.6852 9.72123 11.6025 10.1465 11.4531C10.5662 11.3056 10.8063 11.1158 10.9277 10.873L10.9795 10.7549C11.0776 10.487 11.0316 10.2723 10.9609 10.1123C10.918 10.0155 10.8636 9.93595 10.8203 9.88183C10.7996 9.85598 10.7822 9.83638 10.7715 9.82518L10.7607 9.81542L10.7627 9.8164L10.7646 9.81835C10.6114 9.67972 10.5597 9.46044 10.6338 9.26757C10.7082 9.07475 10.8939 8.94726 11.1006 8.94726C11.5282 8.94719 12.26 8.8956 12.9834 8.73925C13.7297 8.5779 14.3654 8.32602 14.6973 7.99413C15.0087 7.68254 15.0327 7.40213 14.9795 7.16698C14.9332 6.96327 14.8204 6.77099 14.707 6.62792L14.5957 6.50195C14.4933 6.39957 14.4401 6.25769 14.4502 6.11327C14.4605 5.96888 14.5327 5.83599 14.6484 5.74902C14.9558 5.51849 15.4742 4.96086 15.8037 4.3662C15.9675 4.07048 16.0637 3.80137 16.085 3.58593C16.1047 3.38427 16.0578 3.26213 15.9697 3.17382C15.8631 3.06726 15.7102 3.00377 15.4824 2.99707Z" fill="#d97757"/></svg>`
-const themeStyles=isLightTheme?{background:'linear-gradient(135deg, #faf9f5 0%, #f2f1ec 100%)',color:'#131314',border:'1px solid rgba(217, 119, 87, 0.4)',boxShadow:'0 8px 24px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(217, 119, 87, 0.15)'}:{background:'rgba(45, 45, 60, 0.95)',color:'rgba(245, 245, 247, 0.95)',border:'1px solid rgba(255, 255, 255, 0.08)',boxShadow:'0 8px 24px rgba(0, 0, 0, 0.35)'}
-const hint=document.createElement('div')
-hint.id='new-task-hint'
-hint.style.cssText=`
+    countdownRing.title = `剩余${remaining}秒`
+
+    tab.appendChild(countdownRing) // 在textSpan之后
+  }
+
+  // 点击标签切换任务
+  tab.onclick = () => switchTask(task.task_id)
+
+  return tab
+}
+
+// ==================== 任务切换 ====================
+
+/**
+ * 切换到指定任务
+ *
+ * 手动切换当前活动任务，更新服务器状态和UI显示。
+ *
+ * @param {string} taskId - 目标任务ID
+ *
+ * ## 功能说明
+ *
+ * 1. **状态保存**：保存当前任务的输入内容、选项状态
+ * 2. **设置切换标志**：防止轮询冲突
+ * 3. **发送切换请求**：POST `/api/tasks/{taskId}/activate`
+ * 4. **更新UI**：切换活动标签、更新倒计时环颜色
+ * 5. **加载新任务**：获取并显示新任务详情
+ * 6. **重启轮询**：恢复任务列表轮询
+ *
+ * ## 并发控制
+ *
+ * - 设置 `isManualSwitching = true`（防止轮询更新）
+ * - 清除旧的切换定时器（防止竞态条件）
+ * - 5秒后自动清除切换标志
+ *
+ * ## 状态恢复
+ *
+ * - 恢复目标任务的输入框内容
+ * - 恢复目标任务的选项选中状态
+ * - 恢复目标任务的图片列表
+ *
+ * ## 错误处理
+ *
+ * - 请求失败时恢复原活动任务
+ * - 显示错误提示
+ * - 记录错误日志
+ *
+ * ## 注意事项
+ *
+ * - 切换是异步操作
+ * - 切换期间暂停轮询更新
+ * - 切换失败会回滚状态
+ */
+async function switchTask(taskId) {
+  // 保存当前任务的textarea内容、选项勾选状态和图片列表
+  if (activeTaskId) {
+    const textarea = document.getElementById('feedback-text')
+    if (textarea) {
+      taskTextareaContents[activeTaskId] = textarea.value
+      console.log(`已保存任务 ${activeTaskId} 的 textarea 内容`)
+    }
+
+    // 保存选项勾选状态
+    const optionsContainer = document.getElementById('options-container')
+    if (optionsContainer) {
+      const checkboxes = optionsContainer.querySelectorAll('input[type="checkbox"]')
+      const optionsStates = []
+      checkboxes.forEach((checkbox, index) => {
+        optionsStates[index] = checkbox.checked
+      })
+      taskOptionsStates[activeTaskId] = optionsStates
+      console.log(`已保存任务 ${activeTaskId} 的选项勾选状态`)
+    }
+
+    // 保存图片列表（深拷贝，避免引用问题）
+    // 注意：不能简单浅拷贝，因为图片对象包含 blob URL，需要独立管理
+    taskImages[activeTaskId] = selectedImages.map(img => ({
+      ...img
+      // 保留所有字段，包括 blob URL（每个任务独立管理）
+    }))
+    console.log(`已保存任务 ${activeTaskId} 的图片列表 (${selectedImages.length} 张)`)
+  }
+
+  // 设置手动切换标志，防止轮询干扰
+  isManualSwitching = true
+
+  // 分发事件通知其他模块暂停轮询
+  window.dispatchEvent(new CustomEvent('taskSwitchStart', { detail: { taskId } }))
+
+  // 立即更新UI，提升响应速度
+  const oldActiveTaskId = activeTaskId
+  activeTaskId = taskId
+  renderTaskTabs() // 立即更新标签高亮
+
+  // 立即更新圆环颜色，不等待DOM重建
+  updateCountdownRingColors(oldActiveTaskId, taskId)
+
+  // 立即从 currentTasks 获取任务信息并更新内容（不等待 API）
+  const cachedTask = currentTasks.find(t => t.task_id === taskId)
+  if (cachedTask && cachedTask.prompt) {
+    console.log(`使用缓存任务信息立即更新内容: ${taskId}`)
+
+    // 内联 updateTaskIdDisplay 逻辑（避免函数未定义错误）
+    const taskIdContainer = document.getElementById('task-id-container')
+    const taskIdText = document.getElementById('task-id-text')
+    if (taskIdContainer && taskIdText) {
+      if (cachedTask.task_id && cachedTask.task_id.trim()) {
+        taskIdText.textContent = cachedTask.task_id
+        taskIdContainer.classList.remove('hidden')
+      } else {
+        taskIdContainer.classList.add('hidden')
+      }
+    }
+
+    // 更新描述和选项
+    updateDescriptionDisplay(cachedTask.prompt)
+    if (cachedTask.predefined_options) {
+      updateOptionsDisplay(cachedTask.predefined_options)
+    }
+  }
+
+  try {
+    // 后台执行激活请求（不阻塞 UI）
+    fetch(`/api/tasks/${taskId}/activate`, { method: 'POST' })
+      .then(res => res.json())
+      .then(data => {
+        if (!data.success) {
+          console.error('激活任务失败:', data.error)
+        } else {
+          console.log(`任务已激活: ${taskId}`)
+        }
+      })
+      .catch(err => console.error('激活任务失败:', err))
+
+    // 后台异步加载完整详情（用于获取最新选项等）
+    loadTaskDetails(taskId).catch(err => {
+      console.warn('加载任务详情失败，但UI已从缓存更新:', err)
+    })
+  } catch (error) {
+    console.error('切换任务失败:', error)
+  } finally {
+    // 清除旧计时器并重新设置200ms后解除标志
+    if (manualSwitchingTimer) {
+      clearTimeout(manualSwitchingTimer)
+    }
+    manualSwitchingTimer = setTimeout(() => {
+      isManualSwitching = false
+      manualSwitchingTimer = null
+      // 分发事件通知其他模块恢复轮询
+      window.dispatchEvent(new CustomEvent('taskSwitchComplete', { detail: { taskId } }))
+      console.log('任务切换锁定已解除，允许轮询恢复')
+    }, 200)
+  }
+}
+
+/**
+ * 更新圆环颜色
+ *
+ * 切换任务时更新倒计时圆环的颜色（active任务使用主题色）。
+ *
+ * @param {string|null} oldActiveTaskId - 原活动任务ID
+ * @param {string|null} newActiveTaskId - 新活动任务ID
+ *
+ * ## 功能说明
+ *
+ * - 重置旧任务的圆环颜色为灰色
+ * - 设置新任务的圆环颜色为主题色
+ *
+ * ## 颜色规则
+ *
+ * - Active任务：主题色（橙色）
+ * - Pending任务：灰色
+ *
+ * ## 注意事项
+ *
+ * - 元素不存在时会跳过
+ * - 颜色值取自CSS变量
+ */
+function updateCountdownRingColors(oldActiveTaskId, newActiveTaskId) {
+  // 将旧active任务的圆环改为紫色
+  if (oldActiveTaskId) {
+    const oldRing = document.getElementById(`countdown-${oldActiveTaskId}`)
+    if (oldRing) {
+      const oldCircle = oldRing.querySelector('circle')
+      if (oldCircle) {
+        oldCircle.setAttribute('stroke', 'rgba(139, 92, 246, 0.9)')
+      }
+    }
+  }
+
+  // 将新active任务的圆环改为白色
+  if (newActiveTaskId) {
+    const newRing = document.getElementById(`countdown-${newActiveTaskId}`)
+    if (newRing) {
+      const newCircle = newRing.querySelector('circle')
+      if (newCircle) {
+        newCircle.setAttribute('stroke', 'rgba(255, 255, 255, 0.9)')
+      }
+    }
+  }
+}
+
+/**
+ * 加载任务详情
+ *
+ * 从服务器获取任务详情并更新UI显示。
+ *
+ * @param {string} taskId - 任务ID
+ *
+ * ## 功能说明
+ *
+ * 1. **防止过期请求**：检查任务ID是否仍是活动任务
+ * 2. **请求任务详情**：GET `/api/tasks/{taskId}`
+ * 3. **更新UI**：描述、选项、图片、倒计时
+ * 4. **恢复状态**：输入框内容、选项选中状态、图片列表
+ *
+ * ## 竞态条件处理
+ *
+ * - 请求前检查活动任务ID
+ * - 响应后再次检查（防止期间切换任务）
+ * - 不匹配时跳过更新
+ *
+ * ## 错误处理
+ *
+ * - 任务不存在：显示错误提示
+ * - 网络错误：记录错误日志
+ * - 响应失败：显示失败消息
+ *
+ * ## 注意事项
+ *
+ * - 异步操作，可能存在竞态条件
+ * - 使用活动任务ID检查避免更新错误任务
+ * - 请求失败不影响其他功能
+ */
+async function loadTaskDetails(taskId) {
+  try {
+    const response = await fetch(`/api/tasks/${taskId}`)
+    const data = await response.json()
+
+    // 检查任务是否仍然是当前活动任务
+    if (taskId !== activeTaskId) {
+      console.log(`跳过过期的任务详情: ${taskId}（当前活动: ${activeTaskId}）`)
+      return
+    }
+
+    if (data.success) {
+      const task = data.task
+
+      // 更新页面内容
+      // 内联 updateTaskIdDisplay 逻辑（避免函数未定义错误）
+      const taskIdContainer = document.getElementById('task-id-container')
+      const taskIdText = document.getElementById('task-id-text')
+      if (taskIdContainer && taskIdText) {
+        if (task.task_id && task.task_id.trim()) {
+          taskIdText.textContent = task.task_id
+          taskIdContainer.classList.remove('hidden')
+        } else {
+          taskIdContainer.classList.add('hidden')
+        }
+      }
+
+      updateDescriptionDisplay(task.prompt)
+      updateOptionsDisplay(task.predefined_options)
+
+      // 恢复该任务之前保存的textarea内容
+      const textarea = document.getElementById('feedback-text')
+      if (textarea && taskTextareaContents[taskId] !== undefined) {
+        textarea.value = taskTextareaContents[taskId]
+        console.log(`已恢复任务 ${taskId} 的 textarea 内容`)
+      }
+      // 如果之前没有保存过内容，保持当前值（避免在用户正在输入时被轮询调用清空）
+
+      // 恢复该任务之前保存的图片列表
+      if (taskImages[taskId] && taskImages[taskId].length > 0) {
+        // 深拷贝图片对象，避免引用问题
+        selectedImages = taskImages[taskId].map(img => ({ ...img }))
+        // 重新渲染图片预览
+        const previewContainer = document.getElementById('image-previews')
+        if (previewContainer) {
+          previewContainer.innerHTML = ''
+          selectedImages.forEach(imageItem => {
+            renderImagePreview(imageItem, false)
+          })
+          updateImageCounter()
+          updateImagePreviewVisibility()
+        }
+        console.log(`已恢复任务 ${taskId} 的图片列表 (${selectedImages.length} 张)`)
+      }
+      // 如果之前没有保存过图片，保持当前值（避免在用户正在添加图片时被轮询调用清空）
+
+      // 只在倒计时不存在时启动，避免切换标签时重置倒计时
+      if (!taskCountdowns[task.task_id]) {
+        // 使用服务器返回的 remaining_time（剩余时间），而非固定的 auto_resubmit_timeout
+        // 这样刷新页面后倒计时不会重置
+        const remaining = task.remaining_time ?? task.auto_resubmit_timeout
+        const total = task.auto_resubmit_timeout
+        startTaskCountdown(task.task_id, remaining, total)
+        console.log(`首次启动倒计时: ${taskId}, 剩余 ${remaining}s / 总 ${total}s`)
+      } else {
+        console.log(`倒计时已存在，不重置: ${taskId}`)
+      }
+
+      console.log(`已加载任务详情: ${taskId}`)
+    } else {
+      console.error('加载任务详情失败:', data.error)
+    }
+  } catch (error) {
+    console.error('加载任务详情失败:', error)
+  }
+}
+
+/**
+ * 更新描述显示
+ *
+ * 渲染任务描述（Markdown格式）并更新DOM。
+ *
+ * @param {string} prompt - Markdown格式的任务描述
+ *
+ * ## 功能说明
+ *
+ * - 使用 marked.js 同步渲染 Markdown
+ * - 更新描述容器的 HTML 内容
+ * - 处理代码块语法高亮
+ * - 按需加载并渲染 MathJax 数学公式
+ *
+ * ## 安全性
+ *
+ * - Markdown渲染经过sanitize处理
+ * - 防止XSS攻击
+ *
+ * ## 注意事项
+ *
+ * - 异步函数，等待渲染完成
+ * - 容器不存在时会跳过
+ */
+async function updateDescriptionDisplay(prompt) {
+  const descriptionElement = document.getElementById('description')
+  if (!descriptionElement) return
+
+  try {
+    // 同步渲染（立即显示，不使用 requestAnimationFrame）
+    let htmlContent = prompt
+
+    // 使用 marked.js 解析 Markdown
+    if (typeof marked !== 'undefined') {
+      try {
+        htmlContent = marked.parse(prompt)
+      } catch (e) {
+        console.warn('marked.js 解析失败:', e)
+      }
+    }
+
+    // 直接更新 DOM（同步）
+    descriptionElement.innerHTML = htmlContent
+
+    // Prism.js 代码高亮（同步）
+    if (typeof Prism !== 'undefined') {
+      Prism.highlightAllUnder(descriptionElement)
+    }
+
+    // 处理代码块（同步）
+    if (typeof processCodeBlocks === 'function') {
+      processCodeBlocks(descriptionElement)
+    }
+
+    // 处理删除线（同步）
+    if (typeof processStrikethrough === 'function') {
+      processStrikethrough(descriptionElement)
+    }
+
+    console.log('同步渲染 Markdown 完成')
+
+    // MathJax 数学公式渲染（按需加载，不阻塞）
+    // 注意：不能只在 MathJax 已加载时 typeset，否则“首次出现公式”的内容会一直不渲染
+    const textContent = descriptionElement.textContent || ''
+    if (window.loadMathJaxIfNeeded) {
+      window.loadMathJaxIfNeeded(descriptionElement, textContent)
+    } else if (window.MathJax && window.MathJax.typesetPromise) {
+      // 回退：如果 MathJax 已加载但 loadMathJaxIfNeeded 不可用，直接渲染
+      window.MathJax.typesetPromise([descriptionElement]).catch(err => {
+        console.warn('MathJax 渲染失败:', err)
+      })
+    }
+  } catch (error) {
+    console.error('更新描述失败:', error)
+    descriptionElement.textContent = prompt
+  }
+}
+
+/**
+ * 更新选项显示
+ *
+ * 动态创建任务选项的复选框列表。
+ *
+ * @param {Array<string>} options - 选项文本数组
+ *
+ * ## 功能说明
+ *
+ * - 清空选项容器
+ * - 为每个选项创建复选框
+ * - 恢复之前保存的选中状态
+ * - 使用安全的DOM操作
+ *
+ * ## 复选框属性
+ *
+ * - type: checkbox
+ * - value: 选项文本
+ * - class: feedback-option
+ *
+ * ## 状态恢复
+ *
+ * - 从 `taskOptionsStates[activeTaskId]` 恢复选中状态
+ * - 保持用户之前的选择
+ *
+ * ## 安全性
+ *
+ * - 使用 `DOMSecurityHelper` 创建元素
+ * - 防止XSS攻击
+ *
+ * ## 注意事项
+ *
+ * - 容器不存在时会跳过
+ * - 选项数组为空时显示空列表
+ */
+function updateOptionsDisplay(options) {
+  const optionsContainer = document.getElementById('options-container')
+  if (!optionsContainer) return
+
+  // 优先使用该任务之前保存的勾选状态（支持新格式：{id: checked} 和旧格式：[index: checked]）
+  let selectedStates = {}
+  if (activeTaskId && taskOptionsStates[activeTaskId]) {
+    selectedStates = taskOptionsStates[activeTaskId]
+    console.log(`已恢复任务 ${activeTaskId} 的选项勾选状态`)
+  } else {
+    // 如果没有保存的状态，尝试保存当前状态（用于同一任务内的更新）
+    const existingCheckboxes = optionsContainer.querySelectorAll('input[type="checkbox"]')
+    existingCheckboxes.forEach(checkbox => {
+      selectedStates[checkbox.id] = checkbox.checked
+    })
+  }
+
+  // 清空现有选项
+  optionsContainer.innerHTML = ''
+
+  if (options && options.length > 0) {
+    options.forEach((option, index) => {
+      const optionDiv = document.createElement('div')
+      optionDiv.className = 'option-item'
+
+      const checkbox = document.createElement('input')
+      checkbox.type = 'checkbox'
+      checkbox.id = `option-${index}`
+      checkbox.value = option
+
+      // 恢复选中状态（支持新格式：{id: checked} 和旧格式：[index: checked]）
+      const checkboxId = `option-${index}`
+      if (selectedStates[checkboxId] || selectedStates[index]) {
+        checkbox.checked = true
+      }
+
+      const label = document.createElement('label')
+      label.htmlFor = `option-${index}`
+      label.textContent = option
+
+      optionDiv.appendChild(checkbox)
+      optionDiv.appendChild(label)
+      optionsContainer.appendChild(optionDiv)
+    })
+
+    optionsContainer.classList.remove('hidden')
+    optionsContainer.classList.add('visible')
+
+    const separator = document.getElementById('separator')
+    if (separator) {
+      separator.classList.remove('hidden')
+      separator.classList.add('visible')
+    }
+  } else {
+    optionsContainer.classList.add('hidden')
+    optionsContainer.classList.remove('visible')
+  }
+}
+
+/**
+ * 关闭任务
+ *
+ * 删除指定任务，清理相关资源并更新UI。
+ *
+ * @param {string} taskId - 要关闭的任务ID
+ *
+ * ## 功能说明
+ *
+ * 1. **确认操作**：显示确认对话框
+ * 2. **发送删除请求**：DELETE `/api/tasks/{taskId}`
+ * 3. **清理资源**：倒计时、缓存、UI元素
+ * 4. **切换任务**：如果关闭的是活动任务，切换到下一个
+ * 5. **刷新列表**：更新任务列表显示
+ *
+ * ## 资源清理
+ *
+ * - 停止并删除倒计时
+ * - 清除输入框内容缓存
+ * - 清除选项状态缓存
+ * - 清除图片缓存
+ * - 移除标签页DOM元素
+ *
+ * ## 任务切换逻辑
+ *
+ * - 关闭活动任务：自动切换到第一个pending任务
+ * - 关闭非活动任务：不影响当前活动任务
+ *
+ * ## 错误处理
+ *
+ * - 删除失败：显示错误提示
+ * - 记录错误日志
+ *
+ * ## 注意事项
+ *
+ * - 需要用户确认才执行
+ * - 异步操作
+ * - 删除后无法恢复
+ */
+async function closeTask(taskId) {
+  if (!confirm(`确定要关闭任务 ${taskId} 吗？`)) {
+    return
+  }
+
+  try {
+    // 停止该任务的倒计时
+    if (taskCountdowns[taskId]) {
+      clearInterval(taskCountdowns[taskId].timer)
+      delete taskCountdowns[taskId]
+    }
+
+    // 清除该任务保存的所有状态
+    if (taskTextareaContents[taskId] !== undefined) {
+      delete taskTextareaContents[taskId]
+      console.log(`[关闭任务] 已清除任务 ${taskId} 保存的 textarea 内容`)
+    }
+    if (taskOptionsStates[taskId] !== undefined) {
+      delete taskOptionsStates[taskId]
+      console.log(`[关闭任务] 已清除任务 ${taskId} 保存的选项勾选状态`)
+    }
+    if (taskImages[taskId] !== undefined) {
+      delete taskImages[taskId]
+      console.log(`[关闭任务] 已清除任务 ${taskId} 保存的图片列表`)
+    }
+
+    // 从列表中移除
+    currentTasks = currentTasks.filter(t => t.task_id !== taskId)
+
+    // 重新渲染标签页
+    renderTaskTabs()
+
+    // 如果关闭的是活动任务，切换到下一个任务
+    if (activeTaskId === taskId && currentTasks.length > 0) {
+      switchTask(currentTasks[0].task_id)
+    }
+
+    console.log(`已关闭任务: ${taskId}`)
+  } catch (error) {
+    console.error('关闭任务失败:', error)
+  }
+}
+
+// ==================== 独立倒计时管理 ====================
+
+/**
+ * 启动任务倒计时
+ *
+ * 为指定任务启动独立的倒计时计时器，支持自动提交。
+ *
+ * @param {string} taskId - 任务ID
+ * @param {number} remaining - 剩余倒计时秒数（可能是服务器计算的剩余时间）
+ * @param {number} total - 总超时时间（用于计算进度百分比，可选，默认等于 remaining）
+ *
+ * ## 功能说明
+ *
+ * 1. **清理旧计时器**：如果已存在则先清除
+ * 2. **创建计时器**：每秒递减剩余时间
+ * 3. **更新UI**：更新圆环进度和倒计时文本
+ * 4. **自动提交**：倒计时结束时自动提交任务
+ *
+ * ## 倒计时数据结构
+ *
+ * - `remaining`: 剩余秒数
+ * - `timeout`: 总秒数（用于计算进度百分比）
+ * - `timer`: 定时器ID
+ *
+ * ## UI更新
+ *
+ * - 圆环进度：SVG stroke-dashoffset（基于 remaining/timeout）
+ * - 倒计时文本：格式化时间显示
+ * - 主倒计时：如果是活动任务则同步更新
+ *
+ * ## 自动提交
+ *
+ * - 倒计时归零时调用 `autoSubmitTask`
+ * - 清除计时器
+ * - 记录日志
+ *
+ * ## 页面刷新不重置
+ *
+ * - 服务器返回 remaining_time（基于任务创建时间计算）
+ * - 刷新页面后从服务器获取真实剩余时间
+ * - 进度条使用 remaining/timeout 计算，保持视觉一致性
+ *
+ * ## 注意事项
+ *
+ * - 每个任务有独立的倒计时
+ * - 计时器ID存储在 `taskCountdowns` 对象中
+ * - 任务删除时需要清理计时器（防止内存泄漏）
+ */
+function startTaskCountdown(taskId, remaining, total = null) {
+  // 如果没有指定 total，使用 remaining 作为 total（向后兼容）
+  const timeout = total || remaining
+  // 停止该任务的旧倒计时
+  if (taskCountdowns[taskId] && taskCountdowns[taskId].timer) {
+    clearInterval(taskCountdowns[taskId].timer)
+  }
+
+  // 初始化倒计时数据
+  // remaining: 当前剩余秒数（可能是刷新后从服务器获取的）
+  // timeout: 总超时时间（用于计算进度百分比）
+  taskCountdowns[taskId] = {
+    remaining: remaining,
+    timeout: timeout, // 总超时时间，用于计算进度百分比
+    timer: null
+  }
+
+  // 如果是活动任务，更新主倒计时显示
+  if (taskId === activeTaskId) {
+    updateCountdownDisplay(remaining)
+  }
+
+  // 【优化】基于服务器时间计算剩余时间的辅助函数
+  // 解决切换标签页后 JavaScript 定时器不准确的问题
+  function calculateRemainingFromDeadline() {
+    const deadline = window.taskDeadlines[taskId]
+    if (deadline) {
+      // 使用服务器时间偏移校正本地时间
+      const adjustedNow = Date.now() / 1000 + (window.serverTimeOffset || 0)
+      return Math.max(0, Math.floor(deadline - adjustedNow))
+    }
+    // 没有 deadline 信息，使用递减方式（向后兼容）
+    return taskCountdowns[taskId].remaining - 1
+  }
+
+  // 启动定时器
+  taskCountdowns[taskId].timer = setInterval(() => {
+    // 【优化】使用基于 deadline 的计算方式，而非简单递减
+    // 这样即使标签页被切换（导致 JS 定时器不准确），恢复后也能显示正确的剩余时间
+    const newRemaining = calculateRemainingFromDeadline()
+    taskCountdowns[taskId].remaining = newRemaining
+
+    // 更新SVG圆环倒计时
+    const countdownRing = document.getElementById(`countdown-${taskId}`)
+    if (countdownRing) {
+      const remaining = taskCountdowns[taskId].remaining
+      const total = taskCountdowns[taskId].timeout || 250 // 【优化】默认从290改为250
+      const progress = remaining / total // 进度（0-1）
+
+      // 更新SVG circle的stroke-dashoffset
+      const radius = 9
+      const circumference = 2 * Math.PI * radius
+      const offset = circumference * (1 - progress)
+
+      const circle = countdownRing.querySelector('circle')
+      const numberSpan = countdownRing.querySelector('.countdown-number')
+
+      if (circle) {
+        circle.setAttribute('stroke-dashoffset', offset)
+      }
+      if (numberSpan) {
+        numberSpan.textContent = remaining
+      }
+
+      countdownRing.title = `剩余${remaining}秒`
+    }
+
+    // 如果是活动任务，也更新主倒计时
+    if (taskId === activeTaskId) {
+      updateCountdownDisplay(taskCountdowns[taskId].remaining)
+    }
+
+    // 倒计时结束
+    if (taskCountdowns[taskId].remaining <= 0) {
+      clearInterval(taskCountdowns[taskId].timer)
+      // 智能自动提交逻辑：
+      // 1. 如果是当前激活的任务 → 立即自动提交
+      // 2. 如果不是激活任务，检查是否有其他活动任务在处理
+      //    - 如果没有活动任务（用户无响应），也自动提交当前任务
+      //    - 如果有活动任务，说明用户正在处理其他任务，暂不自动提交
+      if (taskId === activeTaskId) {
+        // 当前激活任务超时，直接自动提交
+        autoSubmitTask(taskId)
+      } else {
+        // 非激活任务超时：检查是否真的没有用户活动
+        // 如果当前没有任何激活任务，说明用户完全无响应，也自动提交
+        if (!activeTaskId) {
+          console.log(`非激活任务 ${taskId} 超时，且无活动任务，自动提交`)
+          autoSubmitTask(taskId)
+        } else {
+          console.log(`任务 ${taskId} 超时，但用户正在处理其他任务 ${activeTaskId}，暂不自动提交`)
+        }
+      }
+    }
+  }, 1000)
+
+  console.log(`已启动任务倒计时: ${taskId}, 剩余 ${remaining}s / 总 ${timeout}s`)
+}
+
+/**
+ * 格式化倒计时显示
+ *
+ * 将秒数转换为"分:秒"格式。
+ *
+ * @param {number} seconds - 秒数
+ * @returns {string} 格式化的时间字符串（如"05:30"）
+ *
+ * ## 格式规则
+ *
+ * - 分钟：补零到2位
+ * - 秒钟：补零到2位
+ * - 分隔符：冒号
+ *
+ * ## 示例
+ *
+ * - 90秒 → "01:30"
+ * - 5秒 → "00:05"
+ * - 0秒 → "00:00"
+ */
+function formatCountdown(seconds) {
+  if (seconds > 60) {
+    return `${Math.floor(seconds / 60)}m`
+  }
+  return `${seconds}s`
+}
+
+/**
+ * 自动提交任务
+ *
+ * 倒计时结束时自动提交任务反馈。
+ *
+ * @param {string} taskId - 任务ID
+ *
+ * ## 功能说明
+ *
+ * - 获取当前输入框内容
+ * - 获取已选中的选项
+ * - 调用 `submitTaskFeedback` 提交
+ *
+ * ## 触发时机
+ *
+ * - 任务倒计时归零时自动触发
+ * - 用户未手动提交时生效
+ *
+ * ## 注意事项
+ *
+ * - 仅在倒计时归零时调用
+ * - 提交空内容也会执行
+ * - 异步操作
+ */
+async function autoSubmitTask(taskId) {
+  console.log(`任务 ${taskId} 倒计时结束，自动提交`)
+  // 使用配置的提示语（运行中热更新）：自动提交前实时拉取一次
+  const prompts = await fetchFeedbackPromptsFresh()
+  const defaultMessage =
+    prompts && prompts.resubmit_prompt ? prompts.resubmit_prompt : '请立即调用 interactive_feedback 工具'
+  await submitTaskFeedback(taskId, defaultMessage, [])
+}
+
+/**
+ * 提交任务反馈
+ *
+ * 将用户的反馈内容提交到服务器。
+ *
+ * @param {string} taskId - 任务ID
+ * @param {string} feedbackText - 反馈文本
+ * @param {Array<string>} selectedOptions - 选中的选项列表
+ *
+ * ## 功能说明
+ *
+ * 1. **构建请求体**：包含反馈文本、选项、图片
+ * 2. **发送POST请求**：POST `/api/tasks/{taskId}/feedback`
+ * 3. **处理响应**：成功则继续，失败则显示错误
+ * 4. **刷新列表**：立即同步任务列表
+ * 5. **清理状态**：清除缓存数据
+ *
+ * ## 请求数据
+ *
+ * - `user_input`: 用户输入的文本
+ * - `selected_options`: 选中的选项数组
+ * - `images`: 上传的图片数组
+ *
+ * ## 错误处理
+ *
+ * - 网络错误：记录错误日志
+ * - 服务器错误：显示错误消息
+ * - 请求失败：不清理状态（允许重试）
+ *
+ * ## 注意事项
+ *
+ * - 异步操作
+ * - 提交后立即刷新任务列表
+ * - 失败不影响其他任务
+ */
+async function submitTaskFeedback(taskId, feedbackText, selectedOptions) {
+  try {
+    const formData = new FormData()
+    formData.append('feedback_text', feedbackText)
+    formData.append('selected_options', JSON.stringify(selectedOptions))
+
+    // 添加图片文件
+    selectedImages.forEach((img, index) => {
+      if (img.file) {
+        formData.append(`image_${index}`, img.file)
+      }
+    })
+
+    const response = await fetch(`/api/tasks/${taskId}/submit`, {
+      method: 'POST',
+      body: formData
+    })
+
+    const data = await response.json()
+
+    if (data.success) {
+      console.log(`任务 ${taskId} 提交成功`)
+      // 停止该任务的倒计时
+      if (taskCountdowns[taskId]) {
+        clearInterval(taskCountdowns[taskId].timer)
+        delete taskCountdowns[taskId]
+      }
+      // 清除该任务保存的所有状态
+      if (taskTextareaContents[taskId] !== undefined) {
+        delete taskTextareaContents[taskId]
+        console.log(`已清除任务 ${taskId} 保存的 textarea 内容`)
+      }
+      if (taskOptionsStates[taskId] !== undefined) {
+        delete taskOptionsStates[taskId]
+        console.log(`已清除任务 ${taskId} 保存的选项勾选状态`)
+      }
+      if (taskImages[taskId] !== undefined) {
+        delete taskImages[taskId]
+        console.log(`已清除任务 ${taskId} 保存的图片列表`)
+      }
+
+      // 自动切换到下一个未完成的任务
+      // 延迟执行以等待任务列表更新
+      setTimeout(async () => {
+        // 刷新任务列表获取最新状态
+        await refreshTasksList()
+
+        // 查找下一个未完成的任务（排除当前已完成的任务）
+        const nextTask = currentTasks.find(t => t.task_id !== taskId && t.status !== 'completed')
+        if (nextTask) {
+          console.log(`🔄 自动切换到下一个任务: ${nextTask.task_id}`)
+          switchTask(nextTask.task_id)
+        } else {
+          console.log(`所有任务已完成`)
+        }
+      }, 300)
+    } else {
+      console.error('提交任务失败:', data.error)
+    }
+  } catch (error) {
+    console.error('提交任务反馈失败:', error)
+  }
+}
+
+// ==================== 新任务通知 ====================
+
+/**
+ * 显示新任务视觉提示
+ *
+ * 在标签栏旁边显示临时的新任务提示，提醒用户有新任务到达。
+ *
+ * @param {number} count - 新任务数量
+ *
+ * ## 功能说明
+ *
+ * - 创建临时提示元素
+ * - 显示新任务数量
+ * - 2秒后自动移除
+ * - 使用CSS动画
+ *
+ * ## 视觉效果
+ *
+ * - 橙色背景
+ * - 淡入淡出动画
+ * - 位置：标签栏右侧
+ *
+ * ## 注意事项
+ *
+ * - 提示会自动消失
+ * - 不影响功能
+ * - 仅视觉反馈
+ */
+function showNewTaskVisualHint(count) {
+  const container = document.getElementById('task-tabs-container')
+  if (!container) return
+
+  // 检测当前主题 (light/dark)
+  const html = document.documentElement
+  const currentTheme = html.getAttribute('data-theme')
+  const isLightTheme = currentTheme === 'light'
+
+  // Claude 风格 "Create - 创作" SVG 图标（橙色强调色 #d97757）
+  const createSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 20 20" fill="none" style="flex-shrink: 0; margin-right: 10px;"><path d="M15.5117 1.99707C15.9213 2.0091 16.3438 2.13396 16.6768 2.46679C17.0278 2.81814 17.1209 3.26428 17.0801 3.68261C17.0404 4.08745 16.8765 4.49344 16.6787 4.85058C16.3934 5.36546 15.9941 5.85569 15.6348 6.20898C15.7682 6.41421 15.8912 6.66414 15.9551 6.9453C16.0804 7.4977 15.9714 8.13389 15.4043 8.70116C14.8566 9.24884 13.974 9.54823 13.1943 9.71679C12.7628 9.81003 12.3303 9.86698 11.9473 9.90233C12.0596 10.2558 12.0902 10.7051 11.8779 11.2012L11.8223 11.3203C11.5396 11.8854 11.0275 12.2035 10.4785 12.3965C9.93492 12.5875 9.29028 12.6792 8.65332 12.75C7.99579 12.8231 7.34376 12.8744 6.70117 12.9775C6.14371 13.067 5.63021 13.1903 5.18652 13.3818L5.00585 13.4658C4.53515 14.2245 4.13745 14.9658 3.80957 15.6465C4.43885 15.2764 5.1935 15 5.99999 15C6.27614 15 6.49999 15.2238 6.49999 15.5C6.49999 15.7761 6.27613 16 5.99999 16C5.35538 16 4.71132 16.2477 4.15039 16.6103C3.58861 16.9736 3.14957 17.427 2.91601 17.7773C2.91191 17.7835 2.90568 17.788 2.90136 17.7939C2.88821 17.8119 2.8746 17.8289 2.85937 17.8447C2.85117 17.8533 2.84268 17.8612 2.83398 17.8691C2.81803 17.8835 2.80174 17.897 2.78417 17.9092C2.774 17.9162 2.76353 17.9225 2.75292 17.9287C2.73854 17.9372 2.72412 17.9451 2.70898 17.9521C2.69079 17.9605 2.6723 17.9675 2.65332 17.9736C2.6417 17.9774 2.63005 17.9805 2.61816 17.9834C2.60263 17.9872 2.5871 17.9899 2.57128 17.9922C2.55312 17.9948 2.53511 17.9974 2.5166 17.998C2.50387 17.9985 2.49127 17.9976 2.47851 17.9971C2.45899 17.9962 2.43952 17.9954 2.41992 17.9922C2.40511 17.9898 2.39062 17.9862 2.37597 17.9824C2.36477 17.9795 2.35294 17.9783 2.34179 17.9746C2.33697 17.973 2.33286 17.9695 2.32812 17.9678C2.31042 17.9612 2.29351 17.953 2.27636 17.9443C2.26332 17.9378 2.25053 17.9314 2.23828 17.9238C2.23339 17.9208 2.22747 17.9192 2.22265 17.916C2.21414 17.9103 2.20726 17.9026 2.19921 17.8965C2.18396 17.8849 2.16896 17.8735 2.15527 17.8603C2.14518 17.8507 2.13609 17.8404 2.12695 17.8301C2.11463 17.8161 2.10244 17.8023 2.09179 17.7871C2.08368 17.7756 2.07736 17.7631 2.07031 17.751C2.06168 17.7362 2.05297 17.7216 2.04589 17.706C2.03868 17.6901 2.03283 17.6738 2.02734 17.6572C2.0228 17.6436 2.01801 17.6302 2.01464 17.6162C2.01117 17.6017 2.009 17.587 2.00683 17.5722C2.00411 17.5538 2.00161 17.5354 2.00097 17.5166C2.00054 17.5039 2.00141 17.4912 2.00195 17.4785C2.00279 17.459 2.00364 17.4395 2.00683 17.4199C2.00902 17.4064 2.01327 17.3933 2.0166 17.3799C2.01973 17.3673 2.02123 17.3543 2.02539 17.3418C2.41772 16.1648 3.18163 14.466 4.30468 12.7012C4.31908 12.5557 4.34007 12.3582 4.36914 12.1201C4.43379 11.5907 4.53836 10.8564 4.69921 10.0381C5.0174 8.41955 5.56814 6.39783 6.50585 4.9912L6.73242 4.66894C7.27701 3.93277 7.93079 3.30953 8.61035 2.85156C9.3797 2.33311 10.2221 2 11.001 2C11.7951 2.00025 12.3531 2.35795 12.7012 2.70605C12.7723 2.77723 12.8348 2.84998 12.8896 2.91796C13.2829 2.66884 13.7917 2.39502 14.3174 2.21191C14.6946 2.08056 15.1094 1.98537 15.5117 1.99707ZM17.04 15.5537C17.1486 15.3 17.4425 15.1818 17.6963 15.29C17.95 15.3986 18.0683 15.6925 17.96 15.9463C17.4827 17.0612 16.692 18 15.5 18C14.6309 17.9999 13.9764 17.5003 13.5 16.7978C13.0236 17.5003 12.3691 18 11.5 18C10.6309 17.9999 9.97639 17.5003 9.49999 16.7978C9.02359 17.5003 8.36911 18 7.49999 18C7.22391 17.9999 7 17.7761 6.99999 17.5C6.99999 17.2239 7.22391 17 7.49999 17C8.07039 17 8.6095 16.5593 9.04003 15.5537L9.07421 15.4873C9.16428 15.3412 9.32494 15.25 9.49999 15.25C9.70008 15.25 9.88121 15.3698 9.95996 15.5537L10.042 15.7353C10.4581 16.6125 10.9652 16.9999 11.5 17C12.0704 17 12.6095 16.5593 13.04 15.5537L13.0742 15.4873C13.1643 15.3412 13.3249 15.25 13.5 15.25C13.7001 15.25 13.8812 15.3698 13.96 15.5537L14.042 15.7353C14.4581 16.6125 14.9652 16.9999 15.5 17C16.0704 17 16.6095 16.5593 17.04 15.5537ZM15.4824 2.99707C15.247 2.99022 14.9608 3.04682 14.6465 3.15624C14.0173 3.37541 13.389 3.76516 13.0498 4.01953C12.9277 4.11112 12.7697 4.14131 12.6221 4.10253C12.4745 4.06357 12.3522 3.9591 12.291 3.81933V3.81835C12.2892 3.81468 12.2861 3.80833 12.2822 3.80078C12.272 3.78092 12.2541 3.7485 12.2295 3.70898C12.1794 3.62874 12.1011 3.52019 11.9941 3.41308C11.7831 3.2021 11.4662 3.00024 11.001 2.99999C10.4904 2.99999 9.84173 3.22729 9.16894 3.68066C8.58685 4.07297 8.01568 4.61599 7.5371 5.26269L7.33789 5.54589C6.51634 6.77827 5.99475 8.63369 5.68066 10.2314C5.63363 10.4707 5.5913 10.7025 5.55371 10.9238C7.03031 9.01824 8.94157 7.19047 11.2812 6.05077C11.5295 5.92989 11.8283 6.03301 11.9492 6.28124C12.0701 6.52949 11.967 6.82829 11.7187 6.94921C9.33153 8.11208 7.38648 10.0746 5.91406 12.1103C6.12313 12.0632 6.33385 12.0238 6.54296 11.9902C7.21709 11.8821 7.92723 11.8243 8.54296 11.7558C9.17886 11.6852 9.72123 11.6025 10.1465 11.4531C10.5662 11.3056 10.8063 11.1158 10.9277 10.873L10.9795 10.7549C11.0776 10.487 11.0316 10.2723 10.9609 10.1123C10.918 10.0155 10.8636 9.93595 10.8203 9.88183C10.7996 9.85598 10.7822 9.83638 10.7715 9.82518L10.7607 9.81542L10.7627 9.8164L10.7646 9.81835C10.6114 9.67972 10.5597 9.46044 10.6338 9.26757C10.7082 9.07475 10.8939 8.94726 11.1006 8.94726C11.5282 8.94719 12.26 8.8956 12.9834 8.73925C13.7297 8.5779 14.3654 8.32602 14.6973 7.99413C15.0087 7.68254 15.0327 7.40213 14.9795 7.16698C14.9332 6.96327 14.8204 6.77099 14.707 6.62792L14.5957 6.50195C14.4933 6.39957 14.4401 6.25769 14.4502 6.11327C14.4605 5.96888 14.5327 5.83599 14.6484 5.74902C14.9558 5.51849 15.4742 4.96086 15.8037 4.3662C15.9675 4.07048 16.0637 3.80137 16.085 3.58593C16.1047 3.38427 16.0578 3.26213 15.9697 3.17382C15.8631 3.06726 15.7102 3.00377 15.4824 2.99707Z" fill="#d97757"/></svg>`
+
+  // 主题适配样式
+  const themeStyles = isLightTheme
+    ? {
+        // 浅色主题：温暖的米白背景 + 深色文字
+        background: 'linear-gradient(135deg, #faf9f5 0%, #f2f1ec 100%)',
+        color: '#131314',
+        border: '1px solid rgba(217, 119, 87, 0.4)',
+        boxShadow: '0 8px 24px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(217, 119, 87, 0.15)'
+      }
+    : {
+        // 深色主题：与任务标签区域风格一致
+        background: 'rgba(45, 45, 60, 0.95)',
+        color: 'rgba(245, 245, 247, 0.95)',
+        border: '1px solid rgba(255, 255, 255, 0.08)',
+        boxShadow: '0 8px 24px rgba(0, 0, 0, 0.35)'
+      }
+
+  // 创建提示元素
+  const hint = document.createElement('div')
+  hint.id = 'new-task-hint'
+  hint.style.cssText = `
     position: fixed;
     top: 20px;
     right: 20px;
@@ -401,33 +1870,216 @@ hint.style.cssText=`
     animation: slideInRight 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), fadeOutUp 0.3s ease-in 2.7s forwards;
     pointer-events: none;
   `
-hint.innerHTML=`${createSvg}<span>${count} 个新任务已到达</span>`
-document.body.appendChild(hint)
-setTimeout(()=>{if(hint.parentNode){hint.parentNode.removeChild(hint)}},3000)
-console.log(`显示新任务视觉提示: ${count} 个新任务`)}
-function showNewTaskNotification(count){showNewTaskVisualHint(count)
-if(typeof notificationManager!=='undefined'){notificationManager.sendNotification('AI Intervention Agent',`收到 ${count} 个新任务`,{tag:'new-tasks',requireInteraction:false}).catch(error=>{console.warn('发送新任务通知失败:',error)})}}
-async function initMultiTaskSupport(){console.log('初始化多任务支持...')
-await fetchFeedbackPromptsFresh()
-await refreshTasksList()
-startTasksPolling()
-setInterval(()=>{if(typeof document!=='undefined'&&document.hidden){return}
-if(!tasksPollingTimer){console.warn('⚠️ 任务轮询已停止,自动重新启动')
-startTasksPolling()}},30000)
-const textarea=document.getElementById('feedback-text')
-if(textarea){textarea.addEventListener('input',()=>{if(activeTaskId){taskTextareaContents[activeTaskId]=textarea.value}})
-console.log('✅ 已启用 textarea 实时保存')}
-const optionsContainer=document.getElementById('options-container')
-if(optionsContainer){optionsContainer.addEventListener('change',event=>{if(event.target.type==='checkbox'&&activeTaskId){const checkboxes=optionsContainer.querySelectorAll('input[type="checkbox"]')
-const states={}
-checkboxes.forEach(cb=>{states[cb.id]=cb.checked})
-taskOptionsStates[activeTaskId]=states}})
-console.log('✅ 已启用选项状态实时保存')}
-console.log('多任务支持初始化完成 (包含轮询健康检查和实时保存)')}
-async function refreshTasksList(){const ok=await fetchAndApplyTasks('manual')
-if(ok){tasksPollBackoffMs=TASKS_POLL_BASE_MS
-console.log('任务列表已手动刷新')}
-if(!tasksPollingTimer&&!(typeof document!=='undefined'&&document.hidden)){startTasksPolling()}}
-if(typeof window!=='undefined'){window.multiTaskModule={startTasksPolling,stopTasksPolling,switchTask,closeTask,initMultiTaskSupport,refreshTasksList}
-window.refreshTasksList=refreshTasksList}
-if(typeof document!=='undefined'&&typeof document.addEventListener==='function'){document.addEventListener('DOMContentLoaded',()=>{fetchFeedbackPromptsFresh()})}
+  hint.innerHTML = `${createSvg}<span>${count} 个新任务已到达</span>`
+
+  // 添加到页面
+  document.body.appendChild(hint)
+
+  // 3秒后自动移除
+  setTimeout(() => {
+    if (hint.parentNode) {
+      hint.parentNode.removeChild(hint)
+    }
+  }, 3000)
+
+  console.log(`显示新任务视觉提示: ${count} 个新任务`)
+}
+
+/**
+ * 显示新任务通知
+ *
+ * 保留的函数，用于向后兼容。浏览器通知功能已禁用。
+ *
+ * @param {number} count - 新任务数量（未使用）
+ *
+ * ## 功能说明
+ *
+ * - 此函数当前为空实现
+ * - 保留是为了避免破坏现有调用
+ * - 浏览器通知功能已移除
+ *
+ * ## 历史说明
+ *
+ * - 原用途：显示浏览器桌面通知
+ * - 移除原因：用户体验不佳、权限要求
+ * - 替代方案：使用视觉提示（showNewTaskVisualHint）
+ *
+ * ## 注意事项
+ *
+ * - 不执行任何操作
+ * - 可以安全调用
+ * - 未来可能会移除
+ */
+function showNewTaskNotification(count) {
+  showNewTaskVisualHint(count)
+
+  if (typeof notificationManager !== 'undefined') {
+    notificationManager
+      .sendNotification('AI Intervention Agent', `收到 ${count} 个新任务`, {
+        tag: 'new-tasks',
+        requireInteraction: false
+      })
+      .catch(error => {
+        console.warn('发送新任务通知失败:', error)
+      })
+  }
+}
+
+// ==================== 初始化 ====================
+
+/**
+ * 初始化多任务功能
+ *
+ * 页面加载时初始化多任务管理功能。
+ *
+ * ## 功能说明
+ *
+ * - 启动任务列表轮询
+ * - 加载初始任务列表
+ * - 设置事件监听器
+ *
+ * ## 调用时机
+ *
+ * - 页面DOM加载完成时
+ * - 多任务模块激活时
+ *
+ * ## 初始化步骤
+ *
+ * 1. 启动任务列表轮询（每2秒）
+ * 2. 首次加载任务列表
+ * 3. 渲染初始UI
+ *
+ * ## 注意事项
+ *
+ * - 异步函数
+ * - 只应调用一次
+ * - 依赖DOM已加载
+ */
+async function initMultiTaskSupport() {
+  console.log('初始化多任务支持...')
+
+  // 启动时预加载一次提示语（也会填充设置面板里的 config file）
+  await fetchFeedbackPromptsFresh()
+
+  // 立即获取一次任务列表（不等待轮询）
+  await refreshTasksList()
+
+  // 启动定时轮询
+  startTasksPolling()
+
+  // 轮询健康检查机制（每30秒检查一次轮询器是否还在运行,如果停止则重新启动）
+  setInterval(() => {
+    // 页面不可见：不强行恢复轮询（由 visibilitychange 恢复）
+    if (typeof document !== 'undefined' && document.hidden) {
+      return
+    }
+    if (!tasksPollingTimer) {
+      console.warn('任务轮询已停止，自动重新启动')
+      startTasksPolling()
+    }
+  }, 30000)
+
+  // 【新增】实时保存 textarea 和选项状态
+  // 监听 input 事件，每次输入都保存，避免轮询导致内容丢失
+  const textarea = document.getElementById('feedback-text')
+  if (textarea) {
+    textarea.addEventListener('input', () => {
+      if (activeTaskId) {
+        taskTextareaContents[activeTaskId] = textarea.value
+      }
+    })
+    console.log('已启用 textarea 实时保存')
+  }
+
+  // 监听选项变化
+  const optionsContainer = document.getElementById('options-container')
+  if (optionsContainer) {
+    optionsContainer.addEventListener('change', event => {
+      if (event.target.type === 'checkbox' && activeTaskId) {
+        // 保存所有选项的勾选状态
+        const checkboxes = optionsContainer.querySelectorAll('input[type="checkbox"]')
+        const states = {}
+        checkboxes.forEach(cb => {
+          states[cb.id] = cb.checked
+        })
+        taskOptionsStates[activeTaskId] = states
+      }
+    })
+    console.log('已启用选项状态实时保存')
+  }
+
+  console.log('多任务支持初始化完成 (包含轮询健康检查和实时保存)')
+}
+
+/**
+ * 手动触发任务列表更新
+ *
+ * 立即从服务器获取最新的任务列表，用于提交反馈后的即时同步。
+ *
+ * ## 功能说明
+ *
+ * - 请求 `/api/tasks` 获取最新任务列表
+ * - 更新任务列表和统计信息
+ * - 处理请求失败
+ *
+ * ## 调用时机
+ *
+ * - 提交任务反馈后
+ * - 用户点击刷新按钮
+ * - 需要立即同步状态时
+ *
+ * ## 与轮询的区别
+ *
+ * - 立即执行：不等待轮询间隔
+ * - 手动触发：不是定时自动执行
+ * - 用途不同：用于即时同步而非定期更新
+ *
+ * ## 错误处理
+ *
+ * - 请求失败：记录错误日志
+ * - 不影响轮询机制
+ *
+ * ## 注意事项
+ *
+ * - 异步函数
+ * - 不依赖轮询定时器
+ * - 可以与轮询并行运行
+ */
+async function refreshTasksList() {
+  const ok = await fetchAndApplyTasks('manual')
+  if (ok) {
+    tasksPollBackoffMs = TASKS_POLL_BASE_MS
+    console.log('任务列表已手动刷新')
+  }
+
+  // 手动刷新后确保轮询处于运行态（页面可见时）
+  if (!tasksPollingTimer && !(typeof document !== 'undefined' && document.hidden)) {
+    startTasksPolling()
+  }
+}
+
+// 导出函数供外部使用
+if (typeof window !== 'undefined') {
+  window.multiTaskModule = {
+    startTasksPolling,
+    stopTasksPolling,
+    switchTask,
+    closeTask,
+    initMultiTaskSupport,
+    refreshTasksList // 导出刷新函数
+  }
+
+  // 直接导出常用函数到 window，方便 app.js 调用
+  window.refreshTasksList = refreshTasksList
+}
+
+// ==================== 轻量初始化（无需进入多任务模式也生效） ====================
+// 目的：
+// - 让「设置 → 配置」里的“当前配置文件路径”能在页面打开后自动填充
+// - 让 feedbackPrompts 在任何模式下都能拿到最新配置（支持热更新）
+if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+  document.addEventListener('DOMContentLoaded', () => {
+    // 不阻塞首屏：异步拉取即可
+    fetchFeedbackPromptsFresh()
+  })
+}

--- a/static/js/notification-service-worker.js
+++ b/static/js/notification-service-worker.js
@@ -1,0 +1,46 @@
+self.addEventListener('install', event => {
+  event.waitUntil(self.skipWaiting())
+})
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close()
+
+  const data = event.notification.data || {}
+  const targetUrl = typeof data.url === 'string' && data.url ? data.url : '/'
+
+  event.waitUntil(
+    (async () => {
+      const absoluteTargetUrl = new URL(targetUrl, self.location.origin).toString()
+      const targetPathname = new URL(absoluteTargetUrl).pathname
+      const windowClients = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true
+      })
+
+      for (const client of windowClients) {
+        try {
+          const clientUrl = new URL(client.url, self.location.origin)
+          if (
+            client.url === absoluteTargetUrl ||
+            clientUrl.pathname === targetPathname
+          ) {
+            if ('focus' in client) {
+              await client.focus()
+            }
+            return
+          }
+        } catch (error) {
+          // 忽略无法解析的 client URL，继续尝试其他窗口
+        }
+      }
+
+      if (self.clients.openWindow) {
+        await self.clients.openWindow(absoluteTargetUrl)
+      }
+    })()
+  )
+})

--- a/static/js/notification-service-worker.min.js
+++ b/static/js/notification-service-worker.min.js
@@ -1,0 +1,46 @@
+self.addEventListener('install', event => {
+  event.waitUntil(self.skipWaiting())
+})
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close()
+
+  const data = event.notification.data || {}
+  const targetUrl = typeof data.url === 'string' && data.url ? data.url : '/'
+
+  event.waitUntil(
+    (async () => {
+      const absoluteTargetUrl = new URL(targetUrl, self.location.origin).toString()
+      const targetPathname = new URL(absoluteTargetUrl).pathname
+      const windowClients = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true
+      })
+
+      for (const client of windowClients) {
+        try {
+          const clientUrl = new URL(client.url, self.location.origin)
+          if (
+            client.url === absoluteTargetUrl ||
+            clientUrl.pathname === targetPathname
+          ) {
+            if ('focus' in client) {
+              await client.focus()
+            }
+            return
+          }
+        } catch (error) {
+          // 忽略无法解析的 client URL，继续尝试其他窗口
+        }
+      }
+
+      if (self.clients.openWindow) {
+        await self.clients.openWindow(absoluteTargetUrl)
+      }
+    })()
+  )
+})

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -27,7 +27,6 @@
  *
  * 存储机制：
  *   - localStorage: 本地快速存取
- *   - config.jsonc: 服务端持久化（可选）
  *
  * ========================================================================
  */
@@ -157,27 +156,6 @@ const ThemeManager = (function () {
   }
 
   /**
-   * 同步主题偏好到服务端配置
-   * @param {string} theme - 主题模式
-   */
-  async function syncToServer(theme) {
-    try {
-      const response = await fetch('/api/update-notification-config', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ theme_preference: theme })
-      });
-
-      if (!response.ok) {
-        console.warn('同步主题到服务端失败:', response.status);
-      }
-    } catch (e) {
-      // 静默失败，不影响用户体验
-      console.debug('同步主题到服务端失败:', e);
-    }
-  }
-
-  /**
    * 创建主题切换按钮
    * @returns {HTMLElement}
    */
@@ -261,11 +239,10 @@ const ThemeManager = (function () {
     /**
      * 初始化主题管理器
      * @param {Object} options - 配置选项
-     * @param {boolean} options.syncToServer - 是否同步到服务端
      * @param {string} options.defaultTheme - 默认主题
      */
     init: function (options = {}) {
-      const { syncToServer: doSync = false, defaultTheme = THEMES.AUTO } = options;
+      const { defaultTheme = THEMES.AUTO } = options;
 
       // 监听系统偏好
       listenSystemPreference();

--- a/static/js/theme.min.js
+++ b/static/js/theme.min.js
@@ -1,15 +1,172 @@
-const ThemeManager=(function(){'use strict';const STORAGE_KEY='theme-preference';const THEMES={DARK:'dark',LIGHT:'light',AUTO:'auto'};let currentTheme=THEMES.AUTO;let systemPreference=null;let mediaQuery=null;function detectSystemPreference(){if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches){return THEMES.LIGHT;}
-return THEMES.DARK;}
-function listenSystemPreference(){if(!window.matchMedia)return;mediaQuery=window.matchMedia('(prefers-color-scheme: light)');const handleChange=(e)=>{systemPreference=e.matches?THEMES.LIGHT:THEMES.DARK;console.log('系统主题偏好变更:',systemPreference);if(currentTheme===THEMES.AUTO){applyTheme(systemPreference);}};if(mediaQuery.addEventListener){mediaQuery.addEventListener('change',handleChange);}else if(mediaQuery.addListener){mediaQuery.addListener(handleChange);}
-systemPreference=detectSystemPreference();}
-function applyTheme(theme){const html=document.documentElement;const effectiveTheme=theme===THEMES.AUTO?systemPreference:theme;if(effectiveTheme===THEMES.DARK){html.removeAttribute('data-theme');}else{html.setAttribute('data-theme',effectiveTheme);}
-updateMetaThemeColor(effectiveTheme);window.dispatchEvent(new CustomEvent('theme-changed',{detail:{theme:effectiveTheme,mode:theme}}));console.log('主题已应用:',effectiveTheme,'(模式:',theme+')');}
-function updateMetaThemeColor(theme){let metaThemeColor=document.querySelector('meta[name="theme-color"]');if(!metaThemeColor){metaThemeColor=document.createElement('meta');metaThemeColor.name='theme-color';document.head.appendChild(metaThemeColor);}
-metaThemeColor.content=theme===THEMES.LIGHT?'#f8fafc':'#1a1a1f';}
-function savePreference(theme){try{localStorage.setItem(STORAGE_KEY,theme);}catch(e){console.warn('无法保存主题偏好到 localStorage:',e);}}
-function loadPreference(){try{return localStorage.getItem(STORAGE_KEY);}catch(e){console.warn('无法从 localStorage 加载主题偏好:',e);return null;}}
-async function syncToServer(theme){try{const response=await fetch('/api/update-notification-config',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({theme_preference:theme})});if(!response.ok){console.warn('同步主题到服务端失败:',response.status);}}catch(e){console.debug('同步主题到服务端失败:',e);}}
-function createToggleButton(){const button=document.createElement('button');button.className='theme-toggle-btn';button.setAttribute('aria-label','切换主题');button.setAttribute('title','切换主题');button.innerHTML=`
+/**
+ * ========================================================================
+ * AI Intervention Agent - 主题切换模块 (Theme Switcher)
+ * ========================================================================
+ *
+ * 功能说明：
+ *   - 支持暗色/亮色主题切换
+ *   - 检测并跟随系统颜色偏好
+ *   - 主题偏好持久化存储
+ *   - 平滑过渡动画
+ *
+ * 主题模式：
+ *   - "dark": 强制暗色主题
+ *   - "light": 强制亮色主题
+ *   - "auto": 跟随系统偏好（默认）
+ *
+ * 使用方法：
+ *   // 初始化
+ *   ThemeManager.init();
+ *
+ *   // 切换主题
+ *   ThemeManager.setTheme('light');
+ *   ThemeManager.toggle();
+ *
+ *   // 获取当前主题
+ *   const theme = ThemeManager.getTheme();
+ *
+ * 存储机制：
+ *   - localStorage: 本地快速存取
+ *
+ * ========================================================================
+ */
+
+const ThemeManager = (function () {
+  'use strict';
+
+  // 常量定义
+  const STORAGE_KEY = 'theme-preference';
+  const THEMES = {
+    DARK: 'dark',
+    LIGHT: 'light',
+    AUTO: 'auto'
+  };
+
+  // 内部状态
+  let currentTheme = THEMES.AUTO;
+  let systemPreference = null;
+  let mediaQuery = null;
+
+  /**
+   * 检测系统颜色偏好
+   * @returns {string} 'dark' 或 'light'
+   */
+  function detectSystemPreference() {
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
+      return THEMES.LIGHT;
+    }
+    return THEMES.DARK;
+  }
+
+  /**
+   * 监听系统偏好变化
+   */
+  function listenSystemPreference() {
+    if (!window.matchMedia) return;
+
+    mediaQuery = window.matchMedia('(prefers-color-scheme: light)');
+
+    const handleChange = (e) => {
+      systemPreference = e.matches ? THEMES.LIGHT : THEMES.DARK;
+      console.log('系统主题偏好变更:', systemPreference);
+
+      // 如果是自动模式，跟随系统变化
+      if (currentTheme === THEMES.AUTO) {
+        applyTheme(systemPreference);
+      }
+    };
+
+    // 现代浏览器使用 addEventListener
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', handleChange);
+    } else if (mediaQuery.addListener) {
+      // 兼容旧版浏览器
+      mediaQuery.addListener(handleChange);
+    }
+
+    // 初始化系统偏好
+    systemPreference = detectSystemPreference();
+  }
+
+  /**
+   * 应用主题到 DOM
+   * @param {string} theme - 'dark' 或 'light'
+   */
+  function applyTheme(theme) {
+    const html = document.documentElement;
+    const effectiveTheme = theme === THEMES.AUTO ? systemPreference : theme;
+
+    // 设置 data-theme 属性
+    if (effectiveTheme === THEMES.DARK) {
+      html.removeAttribute('data-theme');
+    } else {
+      html.setAttribute('data-theme', effectiveTheme);
+    }
+
+    // 更新 meta 标签（用于移动端状态栏颜色）
+    updateMetaThemeColor(effectiveTheme);
+
+    // 触发自定义事件
+    window.dispatchEvent(new CustomEvent('theme-changed', {
+      detail: { theme: effectiveTheme, mode: theme }
+    }));
+
+    console.log('主题已应用:', effectiveTheme, '(模式:', theme + ')');
+  }
+
+  /**
+   * 更新 meta theme-color
+   * @param {string} theme - 'dark' 或 'light'
+   */
+  function updateMetaThemeColor(theme) {
+    let metaThemeColor = document.querySelector('meta[name="theme-color"]');
+
+    if (!metaThemeColor) {
+      metaThemeColor = document.createElement('meta');
+      metaThemeColor.name = 'theme-color';
+      document.head.appendChild(metaThemeColor);
+    }
+
+    metaThemeColor.content = theme === THEMES.LIGHT ? '#f8fafc' : '#1a1a1f';
+  }
+
+  /**
+   * 保存主题偏好到 localStorage
+   * @param {string} theme - 主题模式
+   */
+  function savePreference(theme) {
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch (e) {
+      console.warn('无法保存主题偏好到 localStorage:', e);
+    }
+  }
+
+  /**
+   * 从 localStorage 加载主题偏好
+   * @returns {string|null}
+   */
+  function loadPreference() {
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch (e) {
+      console.warn('无法从 localStorage 加载主题偏好:', e);
+      return null;
+    }
+  }
+
+  /**
+   * 创建主题切换按钮
+   * @returns {HTMLElement}
+   */
+  function createToggleButton() {
+    const button = document.createElement('button');
+    button.className = 'theme-toggle-btn';
+    button.setAttribute('aria-label', '切换主题');
+    button.setAttribute('title', '切换主题');
+
+    // 图标 SVG
+    button.innerHTML = `
       <svg class="theme-icon theme-icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <circle cx="12" cy="12" r="5"/>
         <line x1="12" y1="1" x2="12" y2="3"/>
@@ -24,8 +181,155 @@ function createToggleButton(){const button=document.createElement('button');butt
       <svg class="theme-icon theme-icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
       </svg>
-    `;button.addEventListener('click',()=>{const effectiveTheme=currentTheme===THEMES.AUTO?systemPreference:currentTheme;const newTheme=effectiveTheme===THEMES.DARK?THEMES.LIGHT:THEMES.DARK;currentTheme=newTheme;savePreference(newTheme);applyTheme(newTheme);updateToggleButton();});return button;}
-function updateToggleButton(){const effectiveTheme=currentTheme===THEMES.AUTO?systemPreference:currentTheme;const buttons=document.querySelectorAll('.theme-toggle-btn');buttons.forEach(button=>{button.classList.toggle('is-light',effectiveTheme===THEMES.LIGHT);});}
-function bindExistingButtons(){const buttons=document.querySelectorAll('.theme-toggle-btn');buttons.forEach(button=>{if(!button.hasAttribute('data-theme-bound')){button.addEventListener('click',()=>{const effectiveTheme=currentTheme===THEMES.AUTO?systemPreference:currentTheme;const newTheme=effectiveTheme===THEMES.DARK?THEMES.LIGHT:THEMES.DARK;currentTheme=newTheme;savePreference(newTheme);applyTheme(newTheme);updateToggleButton();});button.setAttribute('data-theme-bound','true');console.debug('主题切换按钮已绑定:',button.id||'(无ID)');}});}
-return{init:function(options={}){const{syncToServer:doSync=false,defaultTheme=THEMES.AUTO}=options;listenSystemPreference();const savedTheme=loadPreference();currentTheme=savedTheme||defaultTheme;applyTheme(currentTheme);updateToggleButton();bindExistingButtons();console.log('主题管理器已初始化:',currentTheme);},setTheme:function(theme){if(!Object.values(THEMES).includes(theme)){console.warn('无效的主题:',theme);return;}
-currentTheme=theme;savePreference(theme);applyTheme(theme);updateToggleButton();},toggle:function(){const effectiveTheme=currentTheme===THEMES.AUTO?systemPreference:currentTheme;const newTheme=effectiveTheme===THEMES.DARK?THEMES.LIGHT:THEMES.DARK;this.setTheme(newTheme);},getTheme:function(){return currentTheme;},getEffectiveTheme:function(){return currentTheme===THEMES.AUTO?systemPreference:currentTheme;},insertToggleButton:function(container){const target=typeof container==='string'?document.querySelector(container):container;if(target){const button=createToggleButton();target.appendChild(button);updateToggleButton();}},THEMES:THEMES};})();document.addEventListener('DOMContentLoaded',()=>{ThemeManager.init();});if(typeof module!=='undefined'&&module.exports){module.exports=ThemeManager;}
+    `;
+
+    button.addEventListener('click', () => {
+      // 使用内部 toggle 逻辑，而非 ThemeManager.toggle()
+      const effectiveTheme = currentTheme === THEMES.AUTO ? systemPreference : currentTheme;
+      const newTheme = effectiveTheme === THEMES.DARK ? THEMES.LIGHT : THEMES.DARK;
+
+      currentTheme = newTheme;
+      savePreference(newTheme);
+      applyTheme(newTheme);
+      updateToggleButton();
+    });
+
+    return button;
+  }
+
+  /**
+   * 更新切换按钮状态
+   */
+  function updateToggleButton() {
+    const effectiveTheme = currentTheme === THEMES.AUTO ? systemPreference : currentTheme;
+    const buttons = document.querySelectorAll('.theme-toggle-btn');
+
+    buttons.forEach(button => {
+      button.classList.toggle('is-light', effectiveTheme === THEMES.LIGHT);
+    });
+  }
+
+  /**
+   * 为已存在的按钮绑定点击事件
+   * 注意：使用内部函数而非 ThemeManager 引用，避免 IIFE 作用域问题
+   */
+  function bindExistingButtons() {
+    const buttons = document.querySelectorAll('.theme-toggle-btn');
+    buttons.forEach(button => {
+      // 避免重复绑定
+      if (!button.hasAttribute('data-theme-bound')) {
+        button.addEventListener('click', () => {
+          // 使用内部 toggle 逻辑，而非 ThemeManager.toggle()
+          const effectiveTheme = currentTheme === THEMES.AUTO ? systemPreference : currentTheme;
+          const newTheme = effectiveTheme === THEMES.DARK ? THEMES.LIGHT : THEMES.DARK;
+
+          currentTheme = newTheme;
+          savePreference(newTheme);
+          applyTheme(newTheme);
+          updateToggleButton();
+        });
+        button.setAttribute('data-theme-bound', 'true');
+        console.debug('主题切换按钮已绑定:', button.id || '(无ID)');
+      }
+    });
+  }
+
+  // 公共 API
+  return {
+    /**
+     * 初始化主题管理器
+     * @param {Object} options - 配置选项
+     * @param {string} options.defaultTheme - 默认主题
+     */
+    init: function (options = {}) {
+      const { defaultTheme = THEMES.AUTO } = options;
+
+      // 监听系统偏好
+      listenSystemPreference();
+
+      // 加载保存的偏好
+      const savedTheme = loadPreference();
+      currentTheme = savedTheme || defaultTheme;
+
+      // 应用主题
+      applyTheme(currentTheme);
+      updateToggleButton();
+
+      // 为已存在的按钮绑定点击事件
+      bindExistingButtons();
+
+      console.log('主题管理器已初始化:', currentTheme);
+    },
+
+    /**
+     * 设置主题
+     * @param {string} theme - 'dark', 'light', 或 'auto'
+     */
+    setTheme: function (theme) {
+      if (!Object.values(THEMES).includes(theme)) {
+        console.warn('无效的主题:', theme);
+        return;
+      }
+
+      currentTheme = theme;
+      savePreference(theme);
+      applyTheme(theme);
+      updateToggleButton();
+    },
+
+    /**
+     * 切换主题（dark ↔ light）
+     */
+    toggle: function () {
+      const effectiveTheme = currentTheme === THEMES.AUTO ? systemPreference : currentTheme;
+      const newTheme = effectiveTheme === THEMES.DARK ? THEMES.LIGHT : THEMES.DARK;
+
+      this.setTheme(newTheme);
+    },
+
+    /**
+     * 获取当前主题模式
+     * @returns {string} 'dark', 'light', 或 'auto'
+     */
+    getTheme: function () {
+      return currentTheme;
+    },
+
+    /**
+     * 获取当前生效的主题
+     * @returns {string} 'dark' 或 'light'
+     */
+    getEffectiveTheme: function () {
+      return currentTheme === THEMES.AUTO ? systemPreference : currentTheme;
+    },
+
+    /**
+     * 创建并插入主题切换按钮
+     * @param {HTMLElement|string} container - 容器元素或选择器
+     */
+    insertToggleButton: function (container) {
+      const target = typeof container === 'string'
+        ? document.querySelector(container)
+        : container;
+
+      if (target) {
+        const button = createToggleButton();
+        target.appendChild(button);
+        updateToggleButton();
+      }
+    },
+
+    // 常量导出
+    THEMES: THEMES
+  };
+})();
+
+// 自动初始化
+document.addEventListener('DOMContentLoaded', () => {
+  ThemeManager.init();
+});
+
+// 导出（如果支持模块）
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = ThemeManager;
+}

--- a/task_queue.py
+++ b/task_queue.py
@@ -352,7 +352,7 @@ class TaskQueue:
             return True
 
     def complete_task(self, task_id: str, result: Dict[str, Any]) -> bool:
-        """完成任务并标记为延迟删除 ⭐核心方法
+        """完成任务并标记为延迟删除（核心方法）
 
         将任务标记为已完成并保存结果，**不立即删除**。
 
@@ -561,7 +561,7 @@ class TaskQueue:
             return count
 
     def cleanup_completed_tasks(self, age_seconds: int = 10) -> int:
-        """清理超过指定时间的已完成任务 ⭐后台清理核心方法
+        """清理超过指定时间的已完成任务（后台清理核心方法）
 
         删除完成时间超过 age_seconds 的任务。
 
@@ -623,7 +623,7 @@ class TaskQueue:
             return len(tasks_to_remove)
 
     def _cleanup_loop(self):
-        """后台清理循环 ⭐守护线程入口
+        """后台清理循环（守护线程入口）
 
         后台线程的主循环，定期清理过期的已完成任务。
 

--- a/test_mcp_client.py
+++ b/test_mcp_client.py
@@ -269,39 +269,39 @@ def self_check_image_return_format() -> bool:
 
         parsed = parse_structured_response(response)
         if not isinstance(parsed, list):
-            print("❌ 自检失败：parse_structured_response 未返回 list")
+            print("自检失败：parse_structured_response 未返回 list")
             return False
 
         if not any(isinstance(x, ImageContent) for x in parsed):
-            print("❌ 自检失败：返回结果中没有 ImageContent（可能仍在返回 dict）")
+            print("自检失败：返回结果中没有 ImageContent（可能仍在返回 dict）")
             return False
 
         if not any(isinstance(x, TextContent) for x in parsed):
-            print("❌ 自检失败：返回结果中没有 TextContent")
+            print("自检失败：返回结果中没有 TextContent")
             return False
 
         converted = _convert_to_content(parsed)
         if not converted or not isinstance(converted[0], ImageContent):
             print(
-                "❌ 自检失败：FastMCP 转换后首个块不是 ImageContent（可能被降级成文本）"
+                "自检失败：FastMCP 转换后首个块不是 ImageContent（可能被降级成文本）"
             )
             return False
 
         img0 = converted[0]
         if img0.mimeType != "image/png":
-            print(f"❌ 自检失败：mimeType 不正确：{img0.mimeType!r}")
+            print(f"自检失败：mimeType 不正确：{img0.mimeType!r}")
             return False
 
         if img0.data != "Zg==":
-            print("❌ 自检失败：base64 data 被意外改写")
+            print("自检失败：base64 data 被意外改写")
             return False
 
         print(
-            "✅ 图片返回格式自检通过：ImageContent/TextContent 均可被 FastMCP 正确识别"
+            "图片返回格式自检通过：ImageContent/TextContent 均可被 FastMCP 正确识别"
         )
         return True
     except Exception as e:
-        print(f"❌ 图片返回格式自检异常：{type(e).__name__} - {e}")
+        print(f"图片返回格式自检异常：{type(e).__name__} - {e}")
         return False
 
 

--- a/test_mcp_client.py
+++ b/test_mcp_client.py
@@ -282,9 +282,7 @@ def self_check_image_return_format() -> bool:
 
         converted = _convert_to_content(parsed)
         if not converted or not isinstance(converted[0], ImageContent):
-            print(
-                "自检失败：FastMCP 转换后首个块不是 ImageContent（可能被降级成文本）"
-            )
+            print("自检失败：FastMCP 转换后首个块不是 ImageContent（可能被降级成文本）")
             return False
 
         img0 = converted[0]
@@ -296,9 +294,7 @@ def self_check_image_return_format() -> bool:
             print("自检失败：base64 data 被意外改写")
             return False
 
-        print(
-            "图片返回格式自检通过：ImageContent/TextContent 均可被 FastMCP 正确识别"
-        )
+        print("图片返回格式自检通过：ImageContent/TextContent 均可被 FastMCP 正确识别")
         return True
     except Exception as e:
         print(f"图片返回格式自检异常：{type(e).__name__} - {e}")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -111,6 +111,12 @@ class TestWebFeedbackUIFlaskApp(unittest.TestCase):
         # 可能存在或不存在
         self.assertIn(response.status_code, [200, 404])
 
+    def test_notification_service_worker_route(self):
+        """回归测试：通知 service worker 应可从根路径访问并声明站点级作用域"""
+        response = self.client.get("/notification-service-worker.js")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get("Service-Worker-Allowed"), "/")
+
     def test_static_lottie(self):
         """回归测试：Lottie 动画 JSON 静态路由应可访问（避免退化到 emoji）"""
         response = self.client.get("/static/lottie/sprout.json")
@@ -136,6 +142,9 @@ class TestWebFeedbackUIFlaskApp(unittest.TestCase):
         self.assertIn("renderSproutFallback", js)
         self.assertIn("sproutGrow", js)
         self.assertIn("/static/lottie/sprout.json", js)
+        self.assertIn("/notification-service-worker.js", js)
+        self.assertIn("bindAutoPermissionRequest", js)
+        self.assertIn("showSystemNotification", js)
 
     def test_app_js_has_code_insert_and_paste_guards(self):
         """回归测试：app.js 应保留代码插入与 data URI 粘贴护栏"""
@@ -244,6 +253,46 @@ class TestWebFeedbackUINotificationConfig(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+
+    def test_update_notification_config_partial_merge(self):
+        """回归测试：部分更新不应把未提交的通知配置重置为默认值"""
+        enable_bark = {
+            "barkEnabled": True,
+            "barkUrl": "https://api.day.app/push",
+            "barkDeviceKey": "test_key",
+        }
+        response = self.client.post(
+            "/api/update-notification-config",
+            data=json.dumps(enable_bark),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        partial_update = {"webEnabled": False}
+        response = self.client.post(
+            "/api/update-notification-config",
+            data=json.dumps(partial_update),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get("/api/get-notification-config")
+        self.assertEqual(response.status_code, 200)
+        config = json.loads(response.data)["config"]
+        self.assertFalse(config["web_enabled"])
+        self.assertTrue(config["bark_enabled"])
+        self.assertEqual(config["bark_device_key"], "test_key")
+
+    def test_update_notification_config_ignores_unknown_fields(self):
+        """回归测试：非通知字段不应触发默认值覆盖"""
+        response = self.client.post(
+            "/api/update-notification-config",
+            data=json.dumps({"theme_preference": "light"}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.data)
+        self.assertEqual(result["status"], "success")
 
 
 # ============================================================================

--- a/web_ui.py
+++ b/web_ui.py
@@ -248,7 +248,7 @@ def validate_bind_interface(value: Any) -> str:
     if value in VALID_BIND_INTERFACES:
         if value == "0.0.0.0":
             logger.info(
-                    "bind_interface 设为 0.0.0.0，将监听所有网络接口。"
+                "bind_interface 设为 0.0.0.0，将监听所有网络接口。"
                 "请确保已正确配置 allowed_networks 和防火墙规则。"
             )
         return value
@@ -2159,7 +2159,9 @@ class WebFeedbackUI:
 
                     def normalize_sound_volume(raw_value: Any) -> int:
                         try:
-                            return int(clamp_value(float(raw_value), 0, 100, "sound_volume"))
+                            return int(
+                                clamp_value(float(raw_value), 0, 100, "sound_volume")
+                            )
                         except (TypeError, ValueError):
                             return int(notification_config.get("sound_volume", 80))
 
@@ -2262,7 +2264,13 @@ class WebFeedbackUI:
 
                     manager_updates: Dict[str, Any] = {}
                     changed_keys: list[str] = []
-                    for request_keys, manager_key, config_key, manager_cast, config_cast in field_specs:
+                    for (
+                        request_keys,
+                        manager_key,
+                        config_key,
+                        manager_cast,
+                        config_cast,
+                    ) in field_specs:
                         found, raw_value = first_present(*request_keys)
                         if not found:
                             continue

--- a/web_ui.py
+++ b/web_ui.py
@@ -248,7 +248,7 @@ def validate_bind_interface(value: Any) -> str:
     if value in VALID_BIND_INTERFACES:
         if value == "0.0.0.0":
             logger.info(
-                "⚠️  bind_interface 设为 0.0.0.0，将监听所有网络接口。"
+                    "bind_interface 设为 0.0.0.0，将监听所有网络接口。"
                 "请确保已正确配置 allowed_networks 和防火墙规则。"
             )
         return value
@@ -731,6 +731,7 @@ class WebFeedbackUI:
                 "img-src 'self' data: blob:; "
                 "font-src 'self' data:; "
                 "connect-src 'self'; "
+                "worker-src 'self'; "
                 "frame-ancestors 'none'; "
                 "base-uri 'self'; "
                 "object-src 'none'"
@@ -1635,14 +1636,14 @@ class WebFeedbackUI:
                 - 验证失败的文件不会中断整个提交流程
             """
             # 调试信息：记录请求类型和内容（使用INFO级别确保输出）
-            logger.info(f"🔍 收到提交请求 - Content-Type: {request.content_type}")
-            logger.info(f"🔍 request.files: {dict(request.files)}")
-            logger.info(f"🔍 request.form: {dict(request.form)}")
+            logger.info(f"收到提交请求 - Content-Type: {request.content_type}")
+            logger.info(f"request.files: {dict(request.files)}")
+            logger.info(f"request.form: {dict(request.form)}")
             try:
                 json_data = request.get_json()
-                logger.info(f"🔍 request.json: {json_data}")
+                logger.info(f"request.json: {json_data}")
             except Exception as e:
-                logger.info(f"🔍 无法解析JSON数据: {e}")
+                logger.info(f"无法解析JSON数据: {e}")
 
             # 检查是否有文件上传（优先检查 request.files）
             if request.files:
@@ -2145,50 +2146,140 @@ class WebFeedbackUI:
             try:
                 # 获取前端设置
                 data = request.json or {}
+                if not isinstance(data, dict):
+                    data = {}
 
                 # 尝试导入配置管理器和通知系统
                 try:
                     if not NOTIFICATION_AVAILABLE:
                         raise ImportError("通知系统不可用")
 
-                    # 更新通知管理器配置（不保存到文件，避免双重保存）
-                    notification_manager.update_config_without_save(
-                        enabled=data.get("enabled", True),
-                        web_enabled=data.get("webEnabled", True),
-                        web_permission_auto_request=data.get(
-                            "autoRequestPermission", True
-                        ),
-                        sound_enabled=data.get("soundEnabled", True),
-                        sound_mute=data.get("soundMute", False),
-                        sound_volume=data.get("soundVolume", 80) / 100,
-                        mobile_optimized=data.get("mobileOptimized", True),
-                        mobile_vibrate=data.get("mobileVibrate", True),
-                        bark_enabled=data.get("barkEnabled", False),
-                        bark_url=data.get("barkUrl", ""),
-                        bark_device_key=data.get("barkDeviceKey", ""),
-                        bark_icon=data.get("barkIcon", ""),
-                        bark_action=data.get("barkAction", "none"),
-                    )
-
-                    # 更新配置文件（统一保存，避免重复）
                     config_mgr = get_config()
-                    notification_config = {
-                        "enabled": data.get("enabled", True),
-                        "web_enabled": data.get("webEnabled", True),
-                        "auto_request_permission": data.get(
-                            "autoRequestPermission", True
+                    notification_config = dict(config_mgr.get_section("notification"))
+
+                    def normalize_sound_volume(raw_value: Any) -> int:
+                        try:
+                            return int(clamp_value(float(raw_value), 0, 100, "sound_volume"))
+                        except (TypeError, ValueError):
+                            return int(notification_config.get("sound_volume", 80))
+
+                    def normalize_string(raw_value: Any) -> str:
+                        return "" if raw_value is None else str(raw_value)
+
+                    def first_present(*keys: str) -> tuple[bool, Any]:
+                        for key in keys:
+                            if key in data:
+                                return True, data.get(key)
+                        return False, None
+
+                    field_specs = [
+                        (("enabled",), "enabled", "enabled", lambda v: v, lambda v: v),
+                        (
+                            ("webEnabled", "web_enabled"),
+                            "web_enabled",
+                            "web_enabled",
+                            lambda v: v,
+                            lambda v: v,
                         ),
-                        "sound_enabled": data.get("soundEnabled", True),
-                        "sound_mute": data.get("soundMute", False),
-                        "sound_volume": data.get("soundVolume", 80),
-                        "mobile_optimized": data.get("mobileOptimized", True),
-                        "mobile_vibrate": data.get("mobileVibrate", True),
-                        "bark_enabled": data.get("barkEnabled", False),
-                        "bark_url": data.get("barkUrl", ""),
-                        "bark_device_key": data.get("barkDeviceKey", ""),
-                        "bark_icon": data.get("barkIcon", ""),
-                        "bark_action": data.get("barkAction", "none"),
-                    }
+                        (
+                            ("autoRequestPermission", "auto_request_permission"),
+                            "web_permission_auto_request",
+                            "auto_request_permission",
+                            lambda v: v,
+                            lambda v: v,
+                        ),
+                        (
+                            ("soundEnabled", "sound_enabled"),
+                            "sound_enabled",
+                            "sound_enabled",
+                            lambda v: v,
+                            lambda v: v,
+                        ),
+                        (
+                            ("soundMute", "sound_mute"),
+                            "sound_mute",
+                            "sound_mute",
+                            lambda v: v,
+                            lambda v: v,
+                        ),
+                        (
+                            ("soundVolume", "sound_volume"),
+                            "sound_volume",
+                            "sound_volume",
+                            lambda v: normalize_sound_volume(v) / 100.0,
+                            normalize_sound_volume,
+                        ),
+                        (
+                            ("mobileOptimized", "mobile_optimized"),
+                            "mobile_optimized",
+                            "mobile_optimized",
+                            lambda v: v,
+                            lambda v: v,
+                        ),
+                        (
+                            ("mobileVibrate", "mobile_vibrate"),
+                            "mobile_vibrate",
+                            "mobile_vibrate",
+                            lambda v: v,
+                            lambda v: v,
+                        ),
+                        (
+                            ("barkEnabled", "bark_enabled"),
+                            "bark_enabled",
+                            "bark_enabled",
+                            lambda v: v,
+                            lambda v: v,
+                        ),
+                        (
+                            ("barkUrl", "bark_url"),
+                            "bark_url",
+                            "bark_url",
+                            normalize_string,
+                            normalize_string,
+                        ),
+                        (
+                            ("barkDeviceKey", "bark_device_key"),
+                            "bark_device_key",
+                            "bark_device_key",
+                            normalize_string,
+                            normalize_string,
+                        ),
+                        (
+                            ("barkIcon", "bark_icon"),
+                            "bark_icon",
+                            "bark_icon",
+                            normalize_string,
+                            normalize_string,
+                        ),
+                        (
+                            ("barkAction", "bark_action"),
+                            "bark_action",
+                            "bark_action",
+                            normalize_string,
+                            normalize_string,
+                        ),
+                    ]
+
+                    manager_updates: Dict[str, Any] = {}
+                    changed_keys: list[str] = []
+                    for request_keys, manager_key, config_key, manager_cast, config_cast in field_specs:
+                        found, raw_value = first_present(*request_keys)
+                        if not found:
+                            continue
+                        manager_updates[manager_key] = manager_cast(raw_value)
+                        notification_config[config_key] = config_cast(raw_value)
+                        changed_keys.append(config_key)
+
+                    if not changed_keys:
+                        logger.info("通知配置更新请求未包含可识别字段，已忽略")
+                        return jsonify(
+                            {
+                                "status": "success",
+                                "message": "未检测到需要更新的通知配置字段",
+                            }
+                        )
+
+                    notification_manager.update_config_without_save(**manager_updates)
                     config_mgr.update_section("notification", notification_config)
 
                     logger.info("通知配置已更新到配置文件和内存")
@@ -2493,6 +2584,17 @@ class WebFeedbackUI:
 
             return response
 
+        @self.app.route("/notification-service-worker.js")
+        @self.limiter.exempt
+        def serve_notification_service_worker():
+            """提供通知 service worker，并允许其控制整个站点作用域。"""
+            current_dir = os.path.dirname(os.path.abspath(__file__))
+            js_dir = os.path.join(current_dir, "static", "js")
+            response = send_from_directory(js_dir, "notification-service-worker.js")
+            response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+            response.headers["Service-Worker-Allowed"] = "/"
+            return response
+
         @self.app.route("/static/lottie/<filename>")
         @self.limiter.exempt
         def serve_lottie(filename):
@@ -2782,9 +2884,9 @@ class WebFeedbackUI:
         self.current_task_id = new_task_id
         self.has_content = bool(new_prompt)
         if new_prompt:
-            logger.info(f"📝 内容已更新: {new_prompt[:50]}... (task_id: {new_task_id})")
+            logger.info(f"内容已更新: {new_prompt[:50]}... (task_id: {new_task_id})")
         else:
-            logger.info("📝 内容已清空，显示无有效内容页面")
+            logger.info("内容已清空，显示无有效内容页面")
 
     def _replace_inline_css(self, html_content: str, css_link: str) -> str:
         """替换内联CSS为外部CSS文件引用
@@ -3080,7 +3182,7 @@ class WebFeedbackUI:
             from zeroconf import NonUniqueNameException, ServiceInfo, Zeroconf
         except Exception as e:
             logger.error(f"mDNS 功能不可用：无法导入 zeroconf 依赖: {e}")
-            print("⚠️  mDNS 功能不可用：缺少依赖 zeroconf（请更新依赖/重新安装）。")
+            print("mDNS 功能不可用：缺少依赖 zeroconf（请更新依赖/重新安装）。")
             return
 
         hostname = normalize_mdns_hostname(
@@ -3097,7 +3199,7 @@ class WebFeedbackUI:
         if not publish_ip:
             logger.error("mDNS 发布失败：无法探测可发布的内网 IPv4 地址")
             print(
-                "⚠️  mDNS 发布失败：无法探测可发布的内网 IP（已降级为仅通过 IP/localhost 访问）。"
+                "mDNS 发布失败：无法探测可发布的内网 IP（已降级为仅通过 IP/localhost 访问）。"
             )
             return
 
@@ -3144,9 +3246,9 @@ class WebFeedbackUI:
             logger.error(
                 f"mDNS 发布失败：主机名冲突（{hostname}）。请修改配置中的 mdns.hostname 后重试"
             )
-            print(f"❌ mDNS 发布失败：主机名 {hostname} 可能已被局域网中其他设备占用。")
+            print(f"mDNS 发布失败：主机名 {hostname} 可能已被局域网中其他设备占用。")
             print(
-                "👉 请修改配置中的 mdns.hostname（例如 ai-你的机器名.local），然后重启服务。"
+                "请修改配置中的 mdns.hostname（例如 ai-你的机器名.local），然后重启服务。"
             )
             if config_path:
                 print(f"   配置文件: {config_path}")
@@ -3157,7 +3259,7 @@ class WebFeedbackUI:
             return
         except Exception as e:
             logger.warning(f"mDNS 发布失败（已降级，不影响 Web UI）：{e}")
-            print(f"⚠️  mDNS 发布失败：{e}（已降级为仅通过 IP/localhost 访问）。")
+            print(f"mDNS 发布失败：{e}（已降级为仅通过 IP/localhost 访问）。")
             try:
                 zc.close()
             except Exception:
@@ -3169,7 +3271,7 @@ class WebFeedbackUI:
         self._mdns_hostname = hostname
         self._mdns_publish_ip = publish_ip
 
-        print(f"✨ mDNS 已发布: http://{hostname}:{self.port} (IP: {publish_ip})")
+        print(f"mDNS 已发布: http://{hostname}:{self.port} (IP: {publish_ip})")
 
     def _stop_mdns(self) -> None:
         """停止 mDNS 发布（尽力而为）"""
@@ -3229,18 +3331,18 @@ class WebFeedbackUI:
             - 若self.feedback_result为None，返回空反馈字典
             - 服务器关闭后才返回，适用于单次任务模式
         """
-        print("\n🌐 Web反馈界面已启动")
+        print("\nWeb反馈界面已启动")
         # 0.0.0.0 是“监听所有网卡”的服务端绑定地址，但并不适合作为浏览器访问地址。
         # 部分浏览器/环境访问 http://0.0.0.0:PORT 时可能出现异常（例如权限/请求失败）。
         if self.host == "0.0.0.0":
-            print(f"📍 监听地址: http://{self.host}:{self.port}")
-            print(f"✅ 本机访问（推荐）: http://127.0.0.1:{self.port}")
-            print(f"✅ 本机访问（推荐）: http://localhost:{self.port}")
+            print(f"监听地址: http://{self.host}:{self.port}")
+            print(f"本机访问（推荐）: http://127.0.0.1:{self.port}")
+            print(f"本机访问（推荐）: http://localhost:{self.port}")
             print(
-                f"🔗 SSH端口转发命令: ssh -L {self.port}:localhost:{self.port} user@remote_server"
+                f"SSH端口转发命令: ssh -L {self.port}:localhost:{self.port} user@remote_server"
             )
         else:
-            print(f"📍 请在浏览器中打开: http://{self.host}:{self.port}")
+            print(f"请在浏览器中打开: http://{self.host}:{self.port}")
 
         # mDNS 发布（默认：bind_interface 不是 127.0.0.1 时启用）
         self._start_mdns_if_needed()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- route web notifications through a service worker-backed path and only request notification permission from user interaction-safe flows
- re-enable real new-task notifications, keep partial notification-config updates from resetting unrelated settings, and refresh the settings UI when permission changes
- remove emoji from the touched runtime logs/comments, refresh the generated `.min.js` assets, and apply Ruff formatting fixes required by CI

## Testing
- uv run python -m pytest tests/test_integration.py::TestWebFeedbackUIFlaskApp tests/test_integration.py::TestWebFeedbackUINotificationConfig
- uv run python -m pytest tests/test_notification_providers.py tests/test_notification_manager.py tests/test_notification_config.py
- python3 scripts/minify_assets.py --check
- uv run ruff check .
- uv run ruff format --check .
- manually verified in Chrome: granted notification permission, clicked the test notification button, confirmed the browser/system notification flow and settings status refresh
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb3c3891-2264-431f-99fe-13af133f1807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb3c3891-2264-431f-99fe-13af133f1807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

